### PR TITLE
release(v0.8.2): wiki background progress + cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.1-async-wiki-refresh.md)
-[![Version 0.8.1](https://img.shields.io/badge/version-0.8.1-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md)
+[![Version 0.8.2](https://img.shields.io/badge/version-0.8.2-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.2 (2026-04-24)** — Wiki background progress & cancellation. The `.refresh.lock` now carries `phase` + `modules_total`/`modules_done` + `current_module`; `ctx project check` renders it as `bg_refresh=true (generating 3/12 "libs/foo" pid=1234)`. New `ctx project wiki <path> --stop` sends SIGTERM, cleans up stale locks, and reports the PID. Closes both "Known gaps" called out in v0.8.1: binary-only status and no cancellation primitive. No new deps, no daemon — still a single atomic-write lock file.
+
 **v0.8.1 (2026-04-24)** — Async wiki refresh. `ctx project refresh --wiki-background` (and `ctx project wiki --background --refresh`) detaches the wiki LLM pipeline into a subprocess so the CLI returns immediately on large projects. `ctx project check` surfaces `bg_refresh=<bool>`; the lock file is crash-safe (dead-PID and >1h age are auto-cleared). Closes the "sync wiki blocks the terminal for minutes" gap called out in the v0.8.0 release notes. No new deps.
 
 **Phase 9 complete (2026-04-23, v0.8.0)** — Project Copilot Wrapper (spec-011): new `ctx project` command group (`check`, `refresh`, `wiki`, `ask`) that orchestrates the existing scan/pack/wiki/status primitives into single user-facing actions. Detects and explains the four canonical degraded modes — not scanned, stale index, wiki missing/stale, Qdrant off, ambiguous retrieval — so the common "is the index fresh enough for my question?" and "refresh everything and ask" flows become one command each. No new storage, queue, or LLM dependency — strictly a composition layer over the primitives from previous phases.
@@ -68,6 +70,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md](docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md) (v0.8.2 — Wiki Background Progress & Cancellation)
 - [docs/release/2026-04-24-v0.8.1-async-wiki-refresh.md](docs/release/2026-04-24-v0.8.1-async-wiki-refresh.md) (v0.8.1 — Async Wiki Refresh)
 - [docs/release/2026-04-23-v0.8.0-project-copilot-wrapper.md](docs/release/2026-04-23-v0.8.0-project-copilot-wrapper.md) (v0.8.0 — Project Copilot Wrapper)
 - [docs/release/2026-04-23-v0.7.0-symbol-timeline.md](docs/release/2026-04-23-v0.7.0-symbol-timeline.md) (v0.7.0 — Symbol Timeline Index)
@@ -418,7 +421,8 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **Phase 8** (done, v0.7.0) — Symbol Timeline Index (spec-010): append-only event store, 4 new MCP tools (`lvdcp_when` / `lvdcp_removed_since` / `lvdcp_diff` / `lvdcp_regressions`), `ctx timeline` CLI, Claude Code hooks, release snapshots, pack enrichment, Prometheus metrics, doctor check. SC-001: 31×–88× token savings vs git-log walk.
 - **Phase 9** (done, v0.8.0) — Project Copilot Wrapper (spec-011): new `ctx project` CLI group (`check` / `refresh` / `wiki` / `ask`) that orchestrates existing primitives. Composition layer only — no new storage — so the user has a human-friendly surface above the low-level `lvdcp_*` tools.
 - **v0.8.1** (done) — Async wiki refresh: `--wiki-background` detaches the wiki LLM pipeline into a subprocess so `ctx project refresh` returns immediately on large projects. Crash-safe lock file, `check` surfaces `bg_refresh=<bool>`. No new deps.
-- **Phase 10** (next) — Native onboarding flow, Java/Kotlin/Swift parsers, LLM-based rerank, VS Code marketplace, Obsidian nightly sync.
+- **v0.8.2** (done) — Wiki background progress + cancellation. Lock payload carries `phase` / `modules_total`/`_done` / `current_module`; `ctx project check` renders `bg_refresh=true (generating 3/12 "libs/foo" pid=1234)`. New `--stop` flag sends SIGTERM and cleans up stale locks. Closes both known gaps from v0.8.1. No new deps.
+- **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing
 

--- a/apps/cli/commands/project_cmd.py
+++ b/apps/cli/commands/project_cmd.py
@@ -18,6 +18,7 @@ from libs.copilot import (
     CopilotCheckReport,
     CopilotRefreshReport,
     ask_project,
+    cancel_background_refresh,
     check_project,
     refresh_project,
     refresh_wiki,
@@ -32,6 +33,26 @@ app = typer.Typer(
 # ---- renderers -------------------------------------------------------------
 
 
+def _render_bg_refresh(report: CopilotCheckReport) -> str:
+    """Compact one-line summary of in-flight background wiki refresh.
+
+    Examples:
+      ``false``                                 — no refresh running
+      ``true (starting, pid=1234)``             — spawned, lock seen
+      ``true (generating 3/12 "foo/bar", pid=1234)`` — mid-run
+    """
+    if not report.wiki_refresh_in_progress:
+        return "false"
+    parts: list[str] = [report.wiki_refresh_phase or "running"]
+    if report.wiki_refresh_modules_total is not None:
+        parts.append(f"{report.wiki_refresh_modules_done}/{report.wiki_refresh_modules_total}")
+    if report.wiki_refresh_current_module:
+        parts.append(f'"{report.wiki_refresh_current_module}"')
+    if report.wiki_refresh_pid is not None:
+        parts.append(f"pid={report.wiki_refresh_pid}")
+    return f"true ({' '.join(parts)})"
+
+
 def _render_check(report: CopilotCheckReport, *, as_json: bool) -> str:
     if as_json:
         return report.model_dump_json(indent=2)
@@ -44,10 +65,11 @@ def _render_check(report: CopilotCheckReport, *, as_json: bool) -> str:
         f"  index:           files={report.files} symbols={report.symbols} "
         f"relations={report.relations}"
     )
+    bg_label = _render_bg_refresh(report)
     lines.append(
         f"  wiki:            present={report.wiki_present} "
         f"dirty_modules={report.wiki_dirty_modules} "
-        f"bg_refresh={report.wiki_refresh_in_progress}"
+        f"bg_refresh={bg_label}"
     )
     lines.append(f"  qdrant enabled:  {report.qdrant_enabled}")
     if report.degraded_modes:
@@ -154,7 +176,7 @@ def refresh_cmd(
 
 
 @app.command("wiki")
-def wiki_cmd(
+def wiki_cmd(  # noqa: PLR0913 — each Typer Option is a legit user-facing knob
     path: Path = typer.Argument(  # noqa: B008
         ...,
         exists=True,
@@ -177,12 +199,20 @@ def wiki_cmd(
             "Progress is logged to `.context/wiki/.refresh.log`."
         ),
     ),
+    stop: bool = typer.Option(
+        False,
+        "--stop",
+        help=(
+            "Cancel an in-flight background refresh (sends SIGTERM). "
+            "No-op if no refresh is running."
+        ),
+    ),
     as_json: bool = typer.Option(
         False,
         "--json",
         help=(
             "JSON output. Shape: CopilotRefreshReport with --refresh, "
-            "CopilotCheckReport in read-only mode."
+            "CopilotCheckReport in read-only or --stop mode."
         ),
     ),
 ) -> None:
@@ -191,11 +221,24 @@ def wiki_cmd(
     The ``--json`` shape depends on the mode:
 
     * ``--refresh`` → :class:`libs.copilot.CopilotRefreshReport`
-    * read-only (default) → :class:`libs.copilot.CopilotCheckReport`
+    * read-only (default) and ``--stop`` → :class:`libs.copilot.CopilotCheckReport`
 
     Scripts that need a single stable shape should call
     ``ctx project check --json`` instead.
     """
+    if stop:
+        status = cancel_background_refresh(path)
+        full_report = check_project(path)
+        if as_json:
+            typer.echo(full_report.model_dump_json(indent=2))
+            return
+        if status.pid is not None and not status.stale:
+            typer.echo(f"bg refresh: SIGTERM sent to pid={status.pid}")
+        elif status.stale:
+            typer.echo("bg refresh: stale lock cleared (no live process)")
+        else:
+            typer.echo("bg refresh: none running")
+        return
     if do_refresh:
         report = refresh_wiki(path, all_modules=all_modules, background=background)
         typer.echo(_render_refresh(report, as_json=as_json))
@@ -208,9 +251,11 @@ def wiki_cmd(
     typer.echo(f"project: {full_report.project_name}  ({full_report.project_root})")
     typer.echo(f"  wiki present:    {full_report.wiki_present}")
     typer.echo(f"  dirty modules:   {full_report.wiki_dirty_modules}")
-    typer.echo(f"  bg refresh:      {full_report.wiki_refresh_in_progress}")
+    typer.echo(f"  bg refresh:      {_render_bg_refresh(full_report)}")
     if full_report.wiki_refresh_in_progress:
-        typer.echo("  hint: a background refresh is running — tail `.context/wiki/.refresh.log`")
+        typer.echo(
+            "  hint: tail `.context/wiki/.refresh.log`, or stop with `ctx project wiki <path> --stop`"
+        )
     elif full_report.wiki_dirty_modules > 0:
         typer.echo("  hint: run `ctx project wiki <path> --refresh`")
 

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -22,7 +22,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.1</span>
+        <span>LV_DCP Dashboard &bull; v0.8.2</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md
+++ b/docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md
@@ -1,0 +1,159 @@
+# LV_DCP v0.8.2 — Wiki Background Progress & Cancellation
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** close the two *Known gaps* documented in the `v0.8.1` release
+notes — background wiki refresh now streams per-module progress into the
+lock file, and can be cancelled cleanly via `ctx project wiki <path>
+--stop`.
+
+## Why
+
+`v0.8.1` landed the detached wiki runner but left the user with a binary
+`bg_refresh=true / false` signal and no way to stop a runaway rebuild
+short of `kill <pid>`. Verbatim from the `v0.8.1` notes:
+
+> - No cancellation primitive: once a background refresh is spawned,
+>   stopping it requires `kill <pid>` by hand.
+> - No progress events — only a binary in-progress flag + the tail of
+>   `.refresh.log`.
+
+`v0.8.2` closes both without adding a daemon, socket, or new dependency:
+the lock file gains a progress envelope, the runner writes it at every
+module boundary, and the CLI gets a `--stop` flag that sends SIGTERM and
+leaves the lock cleaned up.
+
+## Shipped
+
+### Lock payload now carries progress
+
+`.context/wiki/.refresh.lock` is still a single atomic JSON blob, but it
+now includes:
+
+| field              | shape              | meaning                                   |
+|--------------------|--------------------|-------------------------------------------|
+| `phase`            | `str`              | `starting` → `loading` → `generating` → `finalizing` |
+| `modules_total`    | `int \| null`      | populated once the runner has loaded the graph |
+| `modules_done`     | `int`              | monotonically non-decreasing              |
+| `current_module`   | `str \| null`      | module path being generated, or `null` between modules |
+
+Writes go through a write-then-`Path.replace` helper (`_atomic_write_lock`)
+so concurrent readers never observe a torn file.
+
+### `BackgroundRefreshStatus` + `CopilotCheckReport` extensions
+
+`libs/copilot/wiki_background.py`:
+
+- New `write_progress(root, *, phase, modules_total=None, modules_done=None, current_module=None)`
+  — merges the four fields into the existing lock payload without
+  touching `pid` / `started_at`.
+- New `cancel_background_refresh(root) -> BackgroundRefreshStatus` —
+  sends SIGTERM to the lock's PID, handles the race where the runner
+  already exited (clears the lock), and returns the snapshot for
+  rendering.
+- `BackgroundRefreshStatus` now carries the four progress fields
+  alongside `pid` / `started_at` / `stale`.
+
+`libs/copilot/models.py` — `CopilotCheckReport` gains five new fields:
+`wiki_refresh_phase`, `wiki_refresh_modules_total`,
+`wiki_refresh_modules_done`, `wiki_refresh_current_module`,
+`wiki_refresh_pid`. All default-safe for existing consumers.
+
+### Runner emits per-module progress
+
+`libs/copilot/_wiki_bg_runner.py`:
+
+- Installs a SIGTERM handler that re-raises as `SystemExit(128+signum)`,
+  so the `finally` block that clears the lock still runs on
+  cancellation.
+- Wraps the wiki update with `write_progress(phase=loading)` before and
+  `write_progress(phase=finalizing)` after the rebuild.
+
+`libs/copilot/orchestrator.py`:
+
+- `_run_wiki_update_in_process(..., on_progress: _WikiProgressCallback | None = None)`
+  — new keyword-only callback. The runner passes a callable that funnels
+  every event into `write_progress`. The loop emits
+  `(done=i, total=N, current=module_path)` *before* each module and
+  `(done=N, total=N, current=None)` at the end. The short-circuit
+  branch (no dirty modules) emits a single `(0, 0, None)` event so the
+  UI can still render "done".
+- `check_project` now calls `read_status(root)` (not just
+  `is_refresh_in_progress`) and populates the five new report fields.
+
+### CLI
+
+`ctx project wiki <path> --stop`:
+
+- Sends SIGTERM to the running refresh, prints
+  `bg refresh: SIGTERM sent to pid={N}`.
+- If the lock is stale (dead PID) it's cleared with
+  `bg refresh: stale lock cleared (no live process)`.
+- If nothing is running: `bg refresh: none running`.
+- `--json` still returns a `CopilotCheckReport`.
+
+`ctx project check` and `ctx project wiki` (read-only) now render the
+new composite status line:
+
+```
+bg_refresh=false
+bg_refresh=true (starting, pid=1234)
+bg_refresh=true (generating 3/12 "libs/foo", pid=1234)
+```
+
+Rendering is centralised in `_render_bg_refresh(report)` — one helper
+used by both commands.
+
+## Tests
+
+- **+7** tests in `tests/unit/copilot/test_wiki_background.py`: initial
+  `phase=starting` on spawn, progress merge preserves `pid`,
+  `current_module=None` reset, atomic write leaves no `.tmp`, cancel
+  happy-path sends SIGTERM, cancel on idle project, cancel clears a
+  stale lock.
+- **+2** tests in `tests/unit/copilot/test_refresh_project.py`:
+  `_run_wiki_update_in_process` fires `on_progress` at every module
+  boundary with a monotonic `done` sequence + final reset to `(N,N,None)`;
+  short-circuit path still emits `(0,0,None)`.
+- **+3** CLI tests in `tests/unit/cli/test_project_cmd.py`: progress
+  surface in `check`, `--stop` sends SIGTERM + reports PID, `--stop` on
+  idle is a clean no-op. `test_check_shows_bg_refresh_flag` updated to
+  the new `bg_refresh=true (...)` format.
+- **Total suite: 1095 passing (+11 vs v0.8.1).** The single failing
+  test (`tests/perf/test_scan_with_timeline.py`) hits an expired remote
+  Qdrant SSL cert — unrelated to this change.
+
+## Design notes
+
+- **Still just a lock file.** No new IPC, no sidecar log, no daemon.
+  The lock's JSON payload is the contract; the runner writes, the
+  reader parses. Atomic writes keep it race-safe.
+- **SIGTERM, not SIGKILL.** The runner's signal handler unwinds
+  `finally` so the lock is cleared even on cancellation. SIGKILL would
+  leave a stale lock and the next invocation would (correctly) see it
+  as `stale=True` and replace it — but at the cost of an extra "stale
+  lock cleared" message. SIGTERM is cleaner.
+- **Progress is advisory, not transactional.** We write progress
+  best-effort; a crash between `write_progress(done=3)` and the actual
+  generation is harmless because the lock is cleared on restart and the
+  wiki state machine recovers from content hashes, not from the
+  progress counter.
+
+## Migration / compat
+
+- Default behaviour unchanged. Foreground refresh (no
+  `--wiki-background`) never touches the new fields.
+- The five new `CopilotCheckReport` fields all default to `None` / `0`;
+  JSON consumers remain source-compatible.
+- No new dependencies. No new config knobs. No database migration.
+
+## Known gaps (carry-forward)
+
+- No resume. Cancelling a refresh mid-run leaves the partially-generated
+  modules in place; re-running `--refresh` picks up the dirty ones
+  again. This is by design — content-hash-driven refresh is the resume
+  mechanism — but worth noting for users expecting a "continue from
+  where it stopped" flow.
+- No live tail. `ctx project check` is still a pull API; the user has
+  to re-run it (or `watch -n 1 ctx project check`) to see progress.
+  Streaming (SSE / websocket) is explicitly out of scope for the CLI.

--- a/libs/copilot/__init__.py
+++ b/libs/copilot/__init__.py
@@ -27,6 +27,7 @@ from libs.copilot.orchestrator import (
 )
 from libs.copilot.wiki_background import (
     BackgroundRefreshStatus,
+    cancel_background_refresh,
     is_refresh_in_progress,
     read_status,
     start_background_refresh,
@@ -39,6 +40,7 @@ __all__ = [
     "CopilotRefreshReport",
     "DegradedMode",
     "ask_project",
+    "cancel_background_refresh",
     "check_project",
     "is_refresh_in_progress",
     "read_status",

--- a/libs/copilot/_wiki_bg_runner.py
+++ b/libs/copilot/_wiki_bg_runner.py
@@ -4,8 +4,12 @@ The parent process (``ctx project refresh --wiki-background``) spawns
 this module with ``subprocess.Popen`` and exits immediately. The runner:
 
 1. writes ``.context/wiki/.refresh.lock`` with its own PID;
-2. calls :func:`libs.copilot.orchestrator.refresh_wiki` synchronously;
-3. unlinks the lock on exit (success or failure).
+2. installs a SIGTERM handler so ``ctx project wiki --stop`` can ask it
+   to exit gracefully without leaving a stale lock behind;
+3. calls the reduced wiki-update pipeline synchronously, streaming
+   per-module progress back into the lock file via
+   :func:`libs.copilot.wiki_background.write_progress`;
+4. unlinks the lock on exit (success, failure, or SIGTERM).
 
 All stdout/stderr is redirected by the parent to
 ``.context/wiki/.refresh.log`` so the user can always inspect what
@@ -19,17 +23,19 @@ import contextlib
 import json
 import logging
 import os
+import signal
 import sys
 import time
 import traceback
 from pathlib import Path
+from types import FrameType
 
 
 def _lock_path(root: Path) -> Path:
     return root / ".context" / "wiki" / ".refresh.lock"
 
 
-def _write_lock(root: Path, *, all_modules: bool) -> None:
+def _write_initial_lock(root: Path, *, all_modules: bool) -> None:
     lock = _lock_path(root)
     lock.parent.mkdir(parents=True, exist_ok=True)
     lock.write_text(
@@ -38,6 +44,7 @@ def _write_lock(root: Path, *, all_modules: bool) -> None:
                 "pid": os.getpid(),
                 "started_at": time.time(),
                 "all_modules": all_modules,
+                "phase": "starting",
             }
         ),
         encoding="utf-8",
@@ -47,6 +54,22 @@ def _write_lock(root: Path, *, all_modules: bool) -> None:
 def _clear_lock(root: Path) -> None:
     with contextlib.suppress(FileNotFoundError):
         _lock_path(root).unlink()
+
+
+def _install_sigterm_handler() -> None:
+    """Convert SIGTERM to SystemExit so ``finally`` blocks run.
+
+    The default SIGTERM handler terminates the process immediately
+    without unwinding — meaning ``finally: _clear_lock(root)`` would
+    never execute and the lock would be left behind for the 1-hour
+    stale-timeout to reap. Raising ``SystemExit`` from the handler
+    lets Python unwind normally.
+    """
+
+    def _handle(signum: int, _frame: FrameType | None) -> None:  # pragma: no cover — signal path
+        raise SystemExit(128 + signum)
+
+    signal.signal(signal.SIGTERM, _handle)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -62,22 +85,45 @@ def main(argv: list[str] | None = None) -> int:
     )
     log = logging.getLogger("lvdcp.wiki_bg")
 
-    _write_lock(root, all_modules=args.all_modules)
+    _write_initial_lock(root, all_modules=args.all_modules)
+    _install_sigterm_handler()
     log.info("start root=%s all_modules=%s", root, args.all_modules)
     exit_code = 0
     try:
-        # Deferred import: `orchestrator` pulls the full scanning stack.
-        # Importing lazily keeps `python -m libs.copilot._wiki_bg_runner --help`
-        # cheap and side-effect-free.
-        from libs.copilot.orchestrator import refresh_wiki  # noqa: PLC0415
-
-        report = refresh_wiki(root, all_modules=args.all_modules)
-        log.info(
-            "done updated=%s refreshed=%s messages=%s",
-            report.wiki_modules_updated,
-            report.wiki_refreshed,
-            report.messages,
+        # Deferred imports: pulling in `orchestrator` brings the full
+        # scanning stack; keeping them lazy makes
+        # ``python -m libs.copilot._wiki_bg_runner --help`` cheap.
+        from libs.copilot.orchestrator import _run_wiki_update_in_process  # noqa: PLC0415
+        from libs.copilot.wiki_background import (  # noqa: PLC0415
+            PHASE_FINALIZING,
+            PHASE_GENERATING,
+            PHASE_LOADING,
+            write_progress,
         )
+
+        write_progress(root, phase=PHASE_LOADING)
+
+        def _on_progress(
+            *, done: int, total: int, current: str | None, phase: str = PHASE_GENERATING
+        ) -> None:
+            write_progress(
+                root,
+                phase=phase,
+                modules_total=total,
+                modules_done=done,
+                current_module=current,
+            )
+
+        updated, messages = _run_wiki_update_in_process(
+            root,
+            all_modules=args.all_modules,
+            on_progress=_on_progress,
+        )
+        write_progress(root, phase=PHASE_FINALIZING)
+        log.info("done updated=%s messages=%s", updated, messages)
+    except SystemExit as exc:
+        log.info("wiki refresh cancelled via signal (exit=%s)", exc.code)
+        exit_code = int(exc.code) if isinstance(exc.code, int) else 143
     except Exception:  # pragma: no cover — surface full trace in the log file
         log.error("wiki refresh crashed:\n%s", traceback.format_exc())
         exit_code = 1

--- a/libs/copilot/models.py
+++ b/libs/copilot/models.py
@@ -57,6 +57,39 @@ class CopilotCheckReport(BaseModel):
             "— i.e. a background wiki refresh spawned via ``--wiki-background`` is running."
         ),
     )
+    wiki_refresh_phase: str | None = Field(
+        default=None,
+        description=(
+            "Current phase of an in-progress background refresh: "
+            "``starting`` | ``loading`` | ``generating`` | ``finalizing``. "
+            "None when no refresh is running."
+        ),
+    )
+    wiki_refresh_modules_total: int | None = Field(
+        default=None,
+        description=(
+            "Total modules the background refresh plans to update. None until the "
+            "runner has enumerated dirty modules."
+        ),
+    )
+    wiki_refresh_modules_done: int = Field(
+        default=0,
+        description="Modules already processed in the current background refresh.",
+    )
+    wiki_refresh_current_module: str | None = Field(
+        default=None,
+        description=(
+            "Module path currently being (re)generated. None between modules or "
+            "when no refresh is running."
+        ),
+    )
+    wiki_refresh_pid: int | None = Field(
+        default=None,
+        description=(
+            "PID of the running wiki-refresh subprocess (so `ctx project wiki --stop` "
+            "can target it). None when no refresh is running."
+        ),
+    )
     qdrant_enabled: bool = Field(
         description="cfg.qdrant.enabled — vector retrieval availability flag"
     )

--- a/libs/copilot/orchestrator.py
+++ b/libs/copilot/orchestrator.py
@@ -22,7 +22,7 @@ from libs.copilot.models import (
     DegradedMode,
 )
 from libs.copilot.wiki_background import (
-    is_refresh_in_progress,
+    read_status,
     start_background_refresh,
 )
 from libs.core.projects_config import load_config
@@ -124,7 +124,7 @@ def check_project(
 
     wiki_present = _wiki_is_present(root)
     wiki_dirty = _count_dirty_wiki_modules(root)
-    wiki_bg_running = is_refresh_in_progress(root)
+    bg_status = read_status(root)
     cfg = _load_config_safe(config_path)
     qdrant_enabled = bool(cfg and cfg.qdrant.enabled)
 
@@ -151,7 +151,12 @@ def check_project(
         relations=card.relations,
         wiki_present=wiki_present,
         wiki_dirty_modules=wiki_dirty,
-        wiki_refresh_in_progress=wiki_bg_running,
+        wiki_refresh_in_progress=bg_status.in_progress,
+        wiki_refresh_phase=bg_status.phase if bg_status.in_progress else None,
+        wiki_refresh_modules_total=(bg_status.modules_total if bg_status.in_progress else None),
+        wiki_refresh_modules_done=(bg_status.modules_done if bg_status.in_progress else 0),
+        wiki_refresh_current_module=(bg_status.current_module if bg_status.in_progress else None),
+        wiki_refresh_pid=bg_status.pid if bg_status.in_progress else None,
         qdrant_enabled=qdrant_enabled,
         degraded_modes=degraded,
     )
@@ -278,10 +283,14 @@ def refresh_wiki(
     )
 
 
-def _run_wiki_update_in_process(
+_WikiProgressCallback = Callable[..., None]
+
+
+def _run_wiki_update_in_process(  # noqa: PLR0915 — progress emission + per-module loop is one cohesive unit
     root: Path,
     *,
     all_modules: bool,
+    on_progress: _WikiProgressCallback | None = None,
 ) -> tuple[int, list[str]]:
     """Reduced port of ``ctx wiki update`` that returns a count + log lines.
 
@@ -289,6 +298,11 @@ def _run_wiki_update_in_process(
     same generator helpers but swallow exceptions per-module so a single
     failure does not abort the batch. The return tuple is
     ``(modules_updated, messages)``.
+
+    ``on_progress`` is an optional keyword-only callback invoked at each
+    module boundary with ``done=<int>, total=<int>, current=<str|None>``.
+    The background runner uses it to stream lock-file progress events;
+    the sync path leaves it ``None``.
     """
     from libs.wiki.generator import generate_wiki_article  # noqa: PLC0415
     from libs.wiki.index_builder import write_index  # noqa: PLC0415
@@ -311,14 +325,19 @@ def _run_wiki_update_in_process(
         modules = get_all_modules(conn) if all_modules else get_dirty_modules(conn)
         if not modules:
             messages.append("wiki: no modules to update")
+            if on_progress is not None:
+                on_progress(done=0, total=0, current=None)
             return 0, messages
 
         files = {f.path: f for f in cache.iter_files()}
         symbols = list(cache.iter_symbols())
         relations = list(cache.iter_relations())
 
-        for mod in modules:
+        total = len(modules)
+        for idx, mod in enumerate(modules):
             module_path = mod["module_path"]
+            if on_progress is not None:
+                on_progress(done=idx, total=total, current=module_path)
             mod_files = [
                 fp for fp in files if fp.startswith(module_path + "/") or fp == module_path
             ]
@@ -359,6 +378,8 @@ def _run_wiki_update_in_process(
 
         write_index(wiki_dir, root.name)
 
+    if on_progress is not None:
+        on_progress(done=len(modules), total=len(modules), current=None)
     messages.append(f"wiki: {updated} module(s) updated")
     return updated, messages
 

--- a/libs/copilot/wiki_background.py
+++ b/libs/copilot/wiki_background.py
@@ -12,13 +12,22 @@ Design notes
   CLI process exits, so ``ctx`` would have to stay alive to finish the
   wiki. A detached ``subprocess.Popen`` survives terminal close.
 - **Lock file as the only IPC** — the runner writes ``.context/wiki/.refresh.lock``
-  as JSON ``{"pid", "started_at"}`` before doing work and unlinks it on
-  exit. ``is_refresh_in_progress`` simply checks the lock and validates
-  the PID. No sockets, no tempdirs, no daemon threads.
+  as JSON ``{"pid", "started_at", "all_modules", "phase",
+  "modules_total", "modules_done", "current_module"}`` before doing work
+  and unlinks it on exit. ``is_refresh_in_progress`` simply checks the
+  lock and validates the PID. No sockets, no tempdirs, no daemon threads.
+- **Progress is best-effort** — the runner rewrites the lock on every
+  module boundary. Readers see an eventually-consistent snapshot; a
+  mid-write read may see the previous payload but never a corrupt one
+  (we write-then-rename).
 - **Stale-lock handling** — if the lock exists but the PID is dead, we
   treat the refresh as finished (crashed). A lock older than
   ``_STALE_LOCK_AFTER_SECONDS`` is also ignored so a zombie runner cannot
   wedge the copilot forever.
+- **Cancellation** — :func:`cancel_background_refresh` sends SIGTERM to
+  the runner. The runner installs a handler that raises ``SystemExit``,
+  which lets its ``finally`` block unlink the lock before the process
+  dies.
 """
 
 from __future__ import annotations
@@ -27,11 +36,13 @@ import contextlib
 import json
 import logging
 import os
+import signal
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +50,12 @@ log = logging.getLogger(__name__)
 LOCK_FILENAME = ".refresh.lock"
 LOG_FILENAME = ".refresh.log"
 _STALE_LOCK_AFTER_SECONDS = 60 * 60  # 1h ceiling for a single wiki refresh
+
+# Canonical phase labels emitted by the runner.
+PHASE_STARTING = "starting"
+PHASE_LOADING = "loading"
+PHASE_GENERATING = "generating"
+PHASE_FINALIZING = "finalizing"
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,6 +67,10 @@ class BackgroundRefreshStatus:
     started_at: float | None
     lock_path: Path | None
     stale: bool = False
+    phase: str | None = None
+    modules_total: int | None = None
+    modules_done: int = 0
+    current_module: str | None = None
 
 
 def _lock_path(root: Path) -> Path:
@@ -70,6 +91,13 @@ def _pid_alive(pid: int) -> bool:
         # Another user owns the PID — treat as alive (conservative).
         return True
     return True
+
+
+def _atomic_write_lock(lock: Path, payload: dict[str, Any]) -> None:
+    """Write-then-rename so a concurrent reader never sees a torn file."""
+    tmp = lock.with_suffix(lock.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    tmp.replace(lock)
 
 
 def read_status(root: Path) -> BackgroundRefreshStatus:
@@ -100,12 +128,21 @@ def read_status(root: Path) -> BackgroundRefreshStatus:
         (pid is not None and not _pid_alive(pid))
         or (started_at is not None and age > _STALE_LOCK_AFTER_SECONDS)
     )
+    phase = payload.get("phase") or None
+    raw_total = payload.get("modules_total")
+    modules_total = int(raw_total) if isinstance(raw_total, int) and raw_total >= 0 else None
+    modules_done = int(payload.get("modules_done", 0) or 0)
+    current_module = payload.get("current_module") or None
     return BackgroundRefreshStatus(
         in_progress=not stale,
         pid=pid,
         started_at=started_at,
         lock_path=lock,
         stale=stale,
+        phase=phase,
+        modules_total=modules_total,
+        modules_done=modules_done,
+        current_module=current_module,
     )
 
 
@@ -168,14 +205,74 @@ def start_background_refresh(
         "pid": pid,
         "started_at": started_at,
         "all_modules": all_modules,
+        "phase": PHASE_STARTING,
     }
-    _lock_path(root).write_text(json.dumps(lock_payload), encoding="utf-8")
+    _atomic_write_lock(_lock_path(root), lock_payload)
     return BackgroundRefreshStatus(
         in_progress=True,
         pid=pid,
         started_at=started_at,
         lock_path=_lock_path(root),
+        phase=PHASE_STARTING,
     )
+
+
+def write_progress(
+    root: Path,
+    *,
+    phase: str,
+    modules_total: int | None = None,
+    modules_done: int | None = None,
+    current_module: str | None = None,
+) -> None:
+    """Merge-update the lock file with fresh progress fields.
+
+    Invoked by the runner at every module boundary. A read-modify-write
+    race is acceptable here: the runner is the only writer for
+    progress fields; the parent only writes the lock once (eagerly) at
+    spawn time. Stale reads remain valid — they just lag by one module.
+    """
+    lock = _lock_path(root)
+    payload: dict[str, Any] = {}
+    if lock.exists():
+        try:
+            payload = json.loads(lock.read_text(encoding="utf-8"))
+        except Exception:  # pragma: no cover — corrupt lock is handled by read_status
+            payload = {}
+    payload["phase"] = phase
+    if modules_total is not None:
+        payload["modules_total"] = modules_total
+    if modules_done is not None:
+        payload["modules_done"] = modules_done
+    # ``current_module=None`` is a legitimate reset (e.g. after the last
+    # module has finished), so we rewrite it unconditionally.
+    payload["current_module"] = current_module
+    _atomic_write_lock(lock, payload)
+
+
+def cancel_background_refresh(root: Path) -> BackgroundRefreshStatus:
+    """Send SIGTERM to the running refresh, if any.
+
+    Returns the status observed just before sending the signal so the
+    caller can render a meaningful "cancelled PID X" message. A
+    non-running or stale refresh is a no-op (the lock is cleared as a
+    side-effect so the next :func:`start_background_refresh` starts
+    clean).
+    """
+    status = read_status(root)
+    if not status.in_progress or status.pid is None:
+        if status.stale and status.lock_path is not None:
+            with contextlib.suppress(FileNotFoundError):
+                status.lock_path.unlink()
+        return status
+    try:
+        os.kill(status.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        # Race: process died between read and kill. Clean up the lock.
+        if status.lock_path is not None:
+            with contextlib.suppress(FileNotFoundError):
+                status.lock_path.unlink()
+    return status
 
 
 def is_refresh_in_progress(root: Path) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.1"
+version = "0.8.2"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/cli/test_project_cmd.py
+++ b/tests/unit/cli/test_project_cmd.py
@@ -190,7 +190,7 @@ def test_refresh_wiki_background_flag_spawns_subprocess(
 
 
 def test_check_shows_bg_refresh_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``ctx project check`` surfaces ``bg_refresh=True`` when lock is live."""
+    """``ctx project check`` surfaces ``bg_refresh=true (...)`` when lock is live."""
     import json as _json
     import time as _time
 
@@ -212,4 +212,90 @@ def test_check_shows_bg_refresh_flag(tmp_path: Path, monkeypatch: pytest.MonkeyP
     runner = CliRunner()
     result = runner.invoke(app, ["project", "check", str(proj)])
     assert result.exit_code == 0, result.stdout
-    assert "bg_refresh=True" in result.stdout
+    assert "bg_refresh=true" in result.stdout
+    assert "pid=11111" in result.stdout
+
+
+def test_check_shows_progress_when_runner_emitted_events(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the runner has already written progress, check surfaces N/M + current module."""
+    import json as _json
+    import time as _time
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _seed_project(proj)
+    scan_project(proj, mode="full")
+
+    wiki_dir = proj / ".context" / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    (wiki_dir / ".refresh.lock").write_text(
+        _json.dumps(
+            {
+                "pid": 22222,
+                "started_at": _time.time(),
+                "all_modules": False,
+                "phase": "generating",
+                "modules_total": 12,
+                "modules_done": 3,
+                "current_module": "libs/foo",
+            }
+        ),
+        encoding="utf-8",
+    )
+    from libs.copilot import wiki_background
+
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["project", "check", str(proj)])
+    assert result.exit_code == 0, result.stdout
+    assert "generating 3/12" in result.stdout
+    assert '"libs/foo"' in result.stdout
+    assert "pid=22222" in result.stdout
+
+
+def test_wiki_stop_sends_sigterm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ctx project wiki <path> --stop`` sends SIGTERM and reports the PID."""
+    import json as _json
+    import signal
+    import time as _time
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _seed_project(proj)
+
+    wiki_dir = proj / ".context" / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    (wiki_dir / ".refresh.lock").write_text(
+        _json.dumps({"pid": 33333, "started_at": _time.time(), "all_modules": False}),
+        encoding="utf-8",
+    )
+
+    from libs.copilot import wiki_background
+
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
+    kills: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        "libs.copilot.wiki_background.os.kill",
+        lambda pid, sig: kills.append((pid, sig)),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["project", "wiki", str(proj), "--stop"])
+    assert result.exit_code == 0, result.stdout
+    assert (33333, signal.SIGTERM) in kills
+    assert "SIGTERM sent to pid=33333" in result.stdout
+
+
+def test_wiki_stop_no_refresh_running_is_noop(tmp_path: Path) -> None:
+    """``--stop`` on an idle project must print a clean message, not crash."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _seed_project(proj)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["project", "wiki", str(proj), "--stop"])
+    assert result.exit_code == 0, result.stdout
+    assert "none running" in result.stdout

--- a/tests/unit/copilot/test_refresh_project.py
+++ b/tests/unit/copilot/test_refresh_project.py
@@ -131,3 +131,76 @@ def test_refresh_wiki_background_flag_sets_bg_started(
     assert report.scanned is True
     assert report.wiki_refreshed is False
     assert report.wiki_refresh_background_started is True
+
+
+def test_run_wiki_update_fires_on_progress_at_every_module_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_run_wiki_update_in_process must call on_progress before + after each module.
+
+    Sequence for N modules should be:
+      (0, N, "pkg"), (1, N, "pkg2"?), …, (N, N, None)
+    """
+    from libs.copilot.orchestrator import _run_wiki_update_in_process
+    from libs.scanning.scanner import scan_project
+
+    _seed_project(tmp_path)
+    scan_project(tmp_path, mode="full")
+
+    def _stub_article(**kw: Any) -> str:
+        return f"# {kw['module_path']}\n\nstubbed.\n"
+
+    monkeypatch.setattr("libs.wiki.generator.generate_wiki_article", _stub_article)
+
+    events: list[tuple[int, int, str | None]] = []
+
+    def _on_progress(*, done: int, total: int, current: str | None, **_kw: Any) -> None:
+        events.append((done, total, current))
+
+    updated, _messages = _run_wiki_update_in_process(
+        tmp_path, all_modules=True, on_progress=_on_progress
+    )
+    assert updated >= 1
+    assert events, "on_progress must fire at least once"
+    total = events[0][1]
+    assert total >= 1
+    # Sequence discipline: `done` is monotonic; final event resets `current=None`.
+    dones = [e[0] for e in events]
+    assert dones == sorted(dones)
+    assert events[-1] == (total, total, None)
+    # No event should report done > total.
+    assert all(d <= total for d in dones)
+
+
+def test_run_wiki_update_on_progress_noop_when_no_modules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Short-circuit path (no dirty modules) must still emit one "0/0" event.
+
+    Gives the UI a way to render "done" even when there was nothing to do.
+    """
+    from libs.copilot.orchestrator import _run_wiki_update_in_process
+    from libs.scanning.scanner import scan_project
+    from libs.storage.sqlite_cache import SqliteCache
+    from libs.wiki.state import ensure_wiki_table, mark_current
+
+    _seed_project(tmp_path)
+    scan_project(tmp_path, mode="full")
+    # Mark every dirty module as current so the second call sees 0 dirty modules.
+    db = tmp_path / ".context" / "cache.db"
+    with SqliteCache(db) as cache:
+        conn = cache._connect()
+        ensure_wiki_table(conn)
+        from libs.wiki.state import get_dirty_modules
+
+        for mod in get_dirty_modules(conn):
+            mark_current(conn, mod["module_path"], "fake.md", mod["source_hash"])
+        conn.commit()
+
+    events: list[tuple[int, int, str | None]] = []
+    _run_wiki_update_in_process(
+        tmp_path,
+        all_modules=False,
+        on_progress=lambda **kw: events.append((kw["done"], kw["total"], kw["current"])),
+    )
+    assert events == [(0, 0, None)]

--- a/tests/unit/copilot/test_wiki_background.py
+++ b/tests/unit/copilot/test_wiki_background.py
@@ -155,3 +155,130 @@ def test_is_refresh_in_progress_is_thin_wrapper(
     monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
     wiki_background.start_background_refresh(tmp_path, _popen=_StubPopen)  # type: ignore[arg-type]
     assert wiki_background.is_refresh_in_progress(tmp_path) is True
+
+
+def test_start_writes_initial_phase_and_surfaces_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fresh spawn → phase='starting', 0 modules done, no current module."""
+    _make_project(tmp_path)
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
+    wiki_background.start_background_refresh(tmp_path, _popen=_StubPopen)  # type: ignore[arg-type]
+
+    status = wiki_background.read_status(tmp_path)
+    assert status.in_progress is True
+    assert status.phase == wiki_background.PHASE_STARTING
+    assert status.modules_total is None
+    assert status.modules_done == 0
+    assert status.current_module is None
+
+
+def test_write_progress_merges_into_existing_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """write_progress must preserve pid/started_at and update progress fields."""
+    _make_project(tmp_path)
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
+    wiki_background.start_background_refresh(tmp_path, _popen=_StubPopen)  # type: ignore[arg-type]
+
+    wiki_background.write_progress(
+        tmp_path,
+        phase=wiki_background.PHASE_GENERATING,
+        modules_total=12,
+        modules_done=3,
+        current_module="libs/foo",
+    )
+    status = wiki_background.read_status(tmp_path)
+    assert status.pid == 99991  # preserved
+    assert status.phase == wiki_background.PHASE_GENERATING
+    assert status.modules_total == 12
+    assert status.modules_done == 3
+    assert status.current_module == "libs/foo"
+
+
+def test_write_progress_allows_resetting_current_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Passing current_module=None (e.g. between modules) must clear the field."""
+    _make_project(tmp_path)
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
+    wiki_background.start_background_refresh(tmp_path, _popen=_StubPopen)  # type: ignore[arg-type]
+    wiki_background.write_progress(
+        tmp_path,
+        phase=wiki_background.PHASE_GENERATING,
+        modules_total=5,
+        modules_done=2,
+        current_module="libs/foo",
+    )
+    wiki_background.write_progress(
+        tmp_path,
+        phase=wiki_background.PHASE_GENERATING,
+        modules_total=5,
+        modules_done=3,
+        current_module=None,
+    )
+    status = wiki_background.read_status(tmp_path)
+    assert status.modules_done == 3
+    assert status.current_module is None
+
+
+def test_write_progress_uses_atomic_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Confirm write_progress never leaves a torn lock on disk."""
+    _make_project(tmp_path)
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
+    wiki_background.start_background_refresh(tmp_path, _popen=_StubPopen)  # type: ignore[arg-type]
+    lock = tmp_path / ".context" / "wiki" / ".refresh.lock"
+    tmp_marker = lock.with_suffix(lock.suffix + ".tmp")
+
+    wiki_background.write_progress(
+        tmp_path,
+        phase=wiki_background.PHASE_GENERATING,
+        modules_total=3,
+        modules_done=1,
+        current_module="libs/foo",
+    )
+    # After a successful rename, no orphaned .tmp must remain.
+    assert lock.exists()
+    assert not tmp_marker.exists()
+
+
+def test_cancel_sends_sigterm_to_live_pid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """cancel_background_refresh issues SIGTERM to the lock's PID."""
+    import signal
+
+    _make_project(tmp_path)
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
+    wiki_background.start_background_refresh(tmp_path, _popen=_StubPopen)  # type: ignore[arg-type]
+
+    kills: list[tuple[int, int]] = []
+
+    def _fake_kill(pid: int, sig: int) -> None:
+        kills.append((pid, sig))
+
+    monkeypatch.setattr("libs.copilot.wiki_background.os.kill", _fake_kill)
+    status = wiki_background.cancel_background_refresh(tmp_path)
+    assert status.pid == 99991
+    # The signal-0 liveness probe fires first (from read_status), then SIGTERM.
+    assert (99991, signal.SIGTERM) in kills
+
+
+def test_cancel_is_noop_when_no_refresh_running(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    status = wiki_background.cancel_background_refresh(tmp_path)
+    assert status.in_progress is False
+    assert status.pid is None
+
+
+def test_cancel_clears_stale_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale lock (dead PID) left behind gets cleaned up by cancel()."""
+    _make_project(tmp_path)
+    lock = tmp_path / ".context" / "wiki" / ".refresh.lock"
+    lock.write_text(
+        json.dumps({"pid": 99991, "started_at": time.time(), "all_modules": False}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: False)
+
+    status = wiki_background.cancel_background_refresh(tmp_path)
+    assert status.stale is True
+    assert not lock.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "lv-dcp"
-version = "0.8.0"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Closes both *Known gaps* from v0.8.1: the `.refresh.lock` now carries `phase` + `modules_total`/`_done` + `current_module` (written at every module boundary via atomic write-then-replace), so `ctx project check` renders `bg_refresh=true (generating 3/12 "libs/foo" pid=1234)`.
- New `ctx project wiki <path> --stop` sends SIGTERM (runner's signal handler unwinds `finally` so the lock is cleaned up), clears stale locks, and reports the PID.
- Five new default-safe fields on `CopilotCheckReport` (`wiki_refresh_phase` / `_modules_total` / `_modules_done` / `_current_module` / `_pid`).
- No new deps, no daemon, no sidecar file — still a single atomic-write lock.

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — 372 source files, no issues
- [x] `uv run python -m pytest -q -m "not eval and not llm"` — **1095 passing** (+11 vs v0.8.1). The single failure (`tests/perf/test_scan_with_timeline.py`) hits an expired remote Qdrant SSL cert and is unrelated.
- [x] New unit coverage: `test_wiki_background` (+7: starting phase, progress merge, atomic write, cancel happy/noop/stale), `test_refresh_project` (+2: progress sequence + empty-modules edge), `test_project_cmd` (+3: progress in check, `--stop` SIGTERM, `--stop` noop).

Release notes: `docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)