### PR TITLE
v0.8.4 — .refresh.last outcome record (close v0.8.3's transition-to-error gap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.3-check-watch.md)
-[![Version 0.8.3](https://img.shields.io/badge/version-0.8.3-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.4-last-refresh.md)
+[![Version 0.8.4](https://img.shields.io/badge/version-0.8.4-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.4 (2026-04-24)** — `.refresh.last` outcome record. After every background wiki refresh finishes (cleanly, via SIGTERM, or crash), the runner's `finally` block writes `.context/wiki/.refresh.last` with `{completed_at, exit_code, modules_updated, elapsed_seconds}`. `ctx project check` then renders `bg_refresh=false (last: ok 12 modules 47s, 3 min ago)` — or `FAILED exit=1 … — see .refresh.log` for crashes. Closes the *"No transition-to-error surface"* gap from v0.8.3: the watcher now tells you *why* the refresh stopped, not just *that* it stopped. No new deps, no new process.
+
 **v0.8.3 (2026-04-24)** — `ctx project check --watch`. Live-tail the background wiki refresh: re-prints the full `check` snapshot every `--interval` seconds (default 2 s) until the refresh transitions to idle, then exits. `--json` mode streams consecutive `CopilotCheckReport` objects separated by blank lines — grep- and `jq -c`-friendly. Closes the *"No live tail"* gap from v0.8.2. No new deps; generator-based polling, not threads.
 
 **v0.8.2 (2026-04-24)** — Wiki background progress & cancellation. The `.refresh.lock` now carries `phase` + `modules_total`/`modules_done` + `current_module`; `ctx project check` renders it as `bg_refresh=true (generating 3/12 "libs/foo" pid=1234)`. New `ctx project wiki <path> --stop` sends SIGTERM, cleans up stale locks, and reports the PID. Closes both "Known gaps" called out in v0.8.1: binary-only status and no cancellation primitive. No new deps, no daemon — still a single atomic-write lock file.
@@ -72,6 +74,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.4-last-refresh.md](docs/release/2026-04-24-v0.8.4-last-refresh.md) (v0.8.4 — `.refresh.last` outcome record)
 - [docs/release/2026-04-24-v0.8.3-check-watch.md](docs/release/2026-04-24-v0.8.3-check-watch.md) (v0.8.3 — `ctx project check --watch`)
 - [docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md](docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md) (v0.8.2 — Wiki Background Progress & Cancellation)
 - [docs/release/2026-04-24-v0.8.1-async-wiki-refresh.md](docs/release/2026-04-24-v0.8.1-async-wiki-refresh.md) (v0.8.1 — Async Wiki Refresh)
@@ -426,6 +429,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.1** (done) — Async wiki refresh: `--wiki-background` detaches the wiki LLM pipeline into a subprocess so `ctx project refresh` returns immediately on large projects. Crash-safe lock file, `check` surfaces `bg_refresh=<bool>`. No new deps.
 - **v0.8.2** (done) — Wiki background progress + cancellation. Lock payload carries `phase` / `modules_total`/`_done` / `current_module`; `ctx project check` renders `bg_refresh=true (generating 3/12 "libs/foo" pid=1234)`. New `--stop` flag sends SIGTERM and cleans up stale locks. Closes both known gaps from v0.8.1. No new deps.
 - **v0.8.3** (done) — `ctx project check --watch`: generator-based live-tail that polls the lock and re-prints the snapshot until the refresh settles. `--json` mode streams consecutive reports separated by blank lines. Closes the "no live tail" gap from v0.8.2. No threads, no new deps.
+- **v0.8.4** (done) — `.refresh.last` outcome record: the runner writes `{completed_at, exit_code, modules_updated, elapsed_seconds}` in its `finally` block (clean / SIGTERM / crash all covered), and `ctx project check` renders `bg_refresh=false (last: ok 12 modules 47s, 3 min ago)` or `FAILED exit=1 … — see .refresh.log`. Closes the "no transition-to-error surface" gap from v0.8.3. No new deps, no new process.
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/cli/commands/project_cmd.py
+++ b/apps/cli/commands/project_cmd.py
@@ -10,6 +10,7 @@ Spec: ``specs/011-project-copilot-wrapper/spec.md``.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import typer
@@ -34,16 +35,69 @@ app = typer.Typer(
 # ---- renderers -------------------------------------------------------------
 
 
+_SIGTERM_EXIT_CODE = 143
+
+
+def _format_age(seconds: float) -> str:
+    """Human-friendly "N ago" for small durations.
+
+    Chosen to match the compact single-line render; we never show sub-
+    second precision here because filesystem mtimes on macOS are second-
+    granular anyway.
+    """
+    seconds = max(0.0, seconds)
+    if seconds < 60:
+        return f"{int(seconds)}s ago"
+    if seconds < 3600:
+        return f"{int(seconds // 60)} min ago"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)} h ago"
+    return f"{int(seconds // 86400)} d ago"
+
+
+def _format_elapsed(seconds: float) -> str:
+    seconds = max(0.0, seconds)
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    return f"{int(seconds // 60)}m{int(seconds % 60):02d}s"
+
+
+def _render_last_refresh(report: CopilotCheckReport, *, now: float | None = None) -> str | None:
+    """Human-friendly "last refresh" summary, or ``None`` if never run.
+
+    Format:
+      ok 12 modules 47s, 3 min ago
+      FAILED exit=1 after 8 modules 12s, 3 min ago — see .refresh.log
+      cancelled after 3 modules 5s, 3 min ago
+    """
+    if report.wiki_last_refresh_completed_at is None:
+        return None
+    exit_code = report.wiki_last_refresh_exit_code or 0
+    modules = report.wiki_last_refresh_modules_updated or 0
+    elapsed = _format_elapsed(report.wiki_last_refresh_elapsed_seconds or 0.0)
+    age = _format_age(
+        (now if now is not None else time.time()) - report.wiki_last_refresh_completed_at
+    )
+    if exit_code == 0:
+        return f"ok {modules} modules {elapsed}, {age}"
+    if exit_code == _SIGTERM_EXIT_CODE:
+        return f"cancelled after {modules} modules {elapsed}, {age}"
+    return f"FAILED exit={exit_code} after {modules} modules {elapsed}, {age} — see .refresh.log"
+
+
 def _render_bg_refresh(report: CopilotCheckReport) -> str:
     """Compact one-line summary of in-flight background wiki refresh.
 
     Examples:
-      ``false``                                 — no refresh running
-      ``true (starting, pid=1234)``             — spawned, lock seen
-      ``true (generating 3/12 "foo/bar", pid=1234)`` — mid-run
+      ``false``                                            — no refresh running, no record
+      ``false (last: ok 12 modules 47s, 3 min ago)``       — previous run succeeded
+      ``false (last: FAILED exit=1 …)``                    — previous run crashed
+      ``true (starting, pid=1234)``                        — spawned, lock seen
+      ``true (generating 3/12 "foo/bar", pid=1234)``       — mid-run
     """
     if not report.wiki_refresh_in_progress:
-        return "false"
+        last = _render_last_refresh(report)
+        return "false" if last is None else f"false (last: {last})"
     parts: list[str] = [report.wiki_refresh_phase or "running"]
     if report.wiki_refresh_modules_total is not None:
         parts.append(f"{report.wiki_refresh_modules_done}/{report.wiki_refresh_modules_total}")

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -22,7 +22,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.3</span>
+        <span>LV_DCP Dashboard &bull; v0.8.4</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.4-last-refresh.md
+++ b/docs/release/2026-04-24-v0.8.4-last-refresh.md
@@ -1,0 +1,145 @@
+# LV_DCP v0.8.4 — `.refresh.last` outcome record
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** close the *"No transition-to-error surface"* Known gap from
+v0.8.3 — when a background wiki refresh finishes (cleanly, via SIGTERM,
+or crash), the runner writes a small outcome record, and `ctx project
+check` surfaces it so the user sees *why* the refresh is no longer
+running.
+
+## Why
+
+v0.8.3 gave us `ctx project check --watch`: when the live tail shows
+`bg_refresh=false`, the watcher exits. That is correct for the happy
+path, but misleading for crashes:
+
+> **No transition-to-error surface.** If the runner crashes mid-run,
+> `wiki_refresh_in_progress` flips to `False` and the generator exits
+> cleanly — the user sees "done" without knowing the crash happened.
+
+v0.8.4 fixes this without adding a new process or a new dependency.
+The runner's `finally` block now writes `.context/wiki/.refresh.last` —
+a tiny JSON file with `{completed_at, exit_code, modules_updated,
+elapsed_seconds}`. `check_project` reads it and `ctx project check`
+renders a human-readable last-run hint next to `bg_refresh=false`.
+
+## Shipped
+
+### New library primitives
+
+```python
+from libs.copilot import (
+    LastRefreshRecord,
+    read_last_refresh,
+    write_last_refresh,
+)
+
+# Runner (in finally):
+write_last_refresh(
+    root,
+    exit_code=0,
+    modules_updated=12,
+    elapsed_seconds=47.3,
+)
+
+# Readers:
+rec = read_last_refresh(root)   # LastRefreshRecord | None
+```
+
+- `LastRefreshRecord` is a frozen dataclass; same write-then-rename
+  atomicity as the existing `.refresh.lock`.
+- Corrupt or malformed files are treated the same as missing — we log
+  a warning and return `None`; the next refresh rewrites the file.
+- `BackgroundRefreshStatus.last_run` surfaces the record alongside
+  the in-progress fields so every `read_status` caller sees both.
+
+### Runner changes (`libs/copilot/_wiki_bg_runner.py`)
+
+The `finally` block now:
+
+1. tracks `modules_updated` incrementally via the `on_progress`
+   callback, so SIGTERM and crash paths report the last observed
+   count (not 0);
+2. re-imports `write_last_refresh` defensively (in case the happy-path
+   import itself was the crash site);
+3. writes `.refresh.last` before unlinking the lock.
+
+Exit codes preserved: `0` clean, `143` SIGTERM, anything else crash.
+
+### `CopilotCheckReport` surface
+
+Four new fields — all `int | None` / `float | None` with defaults so
+existing JSON consumers keep working:
+
+| field                              | meaning                                |
+|------------------------------------|----------------------------------------|
+| `wiki_last_refresh_completed_at`   | unix ts of most recent finish          |
+| `wiki_last_refresh_exit_code`      | 0 / 143 / other                        |
+| `wiki_last_refresh_modules_updated`| last progress checkpoint before exit   |
+| `wiki_last_refresh_elapsed_seconds`| wall-clock of the last run             |
+
+### CLI rendering
+
+When `bg_refresh=false`, the previous output was just `false`. Now:
+
+```
+$ ctx project check .
+project: LV_DCP  (/Users/me/src/LV_DCP)
+  wiki:            present=True dirty_modules=0 bg_refresh=false (last: ok 12 modules 47s, 3 min ago)
+```
+
+Three rendered shapes cover the three exit codes:
+
+- `ok 12 modules 47s, 3 min ago`
+- `cancelled after 3 modules 12s, 3 min ago` (SIGTERM)
+- `FAILED exit=1 after 8 modules 12s, 3 min ago — see .refresh.log`
+
+While a refresh is in progress, the last-run hint is suppressed; the
+live progress line already carries the information the user needs.
+
+## Tests
+
+- **+6** in `tests/unit/copilot/test_wiki_background.py`:
+  round-trip, corrupt-file handling, missing-keys handling, `read_status`
+  surface, atomicity sanity.
+- **+3** in `tests/unit/copilot/test_wiki_bg_runner.py` (new file):
+  runner writes `.refresh.last` on clean exit, SIGTERM, and crash.
+- **+3** in `tests/unit/copilot/test_check_project.py`:
+  report surfaces clean run, crash run, and `None` when never run.
+- **+5** unit tests in `tests/unit/cli/test_project_cmd.py`:
+  `_render_bg_refresh` formats each exit shape correctly and
+  suppresses the hint while running.
+- **Total suite: ~1118 passing (+17 vs v0.8.3).** Ruff + mypy clean.
+
+## Design notes
+
+- **Runner is best-effort persistence.** If `write_last_refresh`
+  itself raises (e.g. ENOSPC), we log the traceback to `.refresh.log`
+  and still clear the lock — no new failure mode is introduced.
+- **No schema version field yet.** Forward compat is handled by
+  treating any payload missing required keys as "no record". When we
+  need to evolve the format (e.g. add an `error_tail: str` surface),
+  we'll bump a schema number and add a branch.
+- **Age rendered in coarse units.** We never show sub-second
+  precision because macOS filesystem mtimes are second-granular and
+  the age is always a rough "how long ago" hint, not a timer.
+
+## Migration / compat
+
+- `.context/wiki/.refresh.last` is created lazily on first refresh.
+  Projects that have never run a background refresh see
+  `bg_refresh=false` unchanged (no `last:` clause).
+- All four new `CopilotCheckReport` fields default to `None`; JSON
+  consumers must treat them as optional.
+- No new deps, no DB migration, no config knob.
+
+## Known gaps (carry-forward)
+
+- **No error-tail surface.** We know the exit code but not the final
+  log lines. A future release could shell out to `tail -n 20
+  .refresh.log` or persist a `last_error: str` field — but pulling
+  the log file is fine for now.
+- **No retry / auto-heal.** A crashed refresh is reported, not
+  retried. The user still has to run `ctx project refresh
+  --wiki-background` manually.

--- a/libs/copilot/__init__.py
+++ b/libs/copilot/__init__.py
@@ -28,10 +28,13 @@ from libs.copilot.orchestrator import (
 )
 from libs.copilot.wiki_background import (
     BackgroundRefreshStatus,
+    LastRefreshRecord,
     cancel_background_refresh,
     is_refresh_in_progress,
+    read_last_refresh,
     read_status,
     start_background_refresh,
+    write_last_refresh,
 )
 
 __all__ = [
@@ -40,13 +43,16 @@ __all__ = [
     "CopilotCheckReport",
     "CopilotRefreshReport",
     "DegradedMode",
+    "LastRefreshRecord",
     "ask_project",
     "cancel_background_refresh",
     "check_project",
     "is_refresh_in_progress",
+    "read_last_refresh",
     "read_status",
     "refresh_project",
     "refresh_wiki",
     "start_background_refresh",
     "watch_check_project",
+    "write_last_refresh",
 ]

--- a/libs/copilot/_wiki_bg_runner.py
+++ b/libs/copilot/_wiki_bg_runner.py
@@ -89,6 +89,13 @@ def main(argv: list[str] | None = None) -> int:
     _install_sigterm_handler()
     log.info("start root=%s all_modules=%s", root, args.all_modules)
     exit_code = 0
+    # ``modules_updated`` reflects modules actually refreshed before exit.
+    # For clean runs it equals the return value of
+    # ``_run_wiki_update_in_process``; for SIGTERM/crash it's the count
+    # reported by the last progress callback, so the user sees
+    # "got through 3/12" instead of a silent partial.
+    modules_updated = 0
+    started_at = time.time()
     try:
         # Deferred imports: pulling in `orchestrator` brings the full
         # scanning stack; keeping them lazy makes
@@ -106,6 +113,8 @@ def main(argv: list[str] | None = None) -> int:
         def _on_progress(
             *, done: int, total: int, current: str | None, phase: str = PHASE_GENERATING
         ) -> None:
+            nonlocal modules_updated
+            modules_updated = done
             write_progress(
                 root,
                 phase=phase,
@@ -119,6 +128,7 @@ def main(argv: list[str] | None = None) -> int:
             all_modules=args.all_modules,
             on_progress=_on_progress,
         )
+        modules_updated = max(modules_updated, int(updated))
         write_progress(root, phase=PHASE_FINALIZING)
         log.info("done updated=%s messages=%s", updated, messages)
     except SystemExit as exc:
@@ -128,6 +138,22 @@ def main(argv: list[str] | None = None) -> int:
         log.error("wiki refresh crashed:\n%s", traceback.format_exc())
         exit_code = 1
     finally:
+        # ``write_last_refresh`` must succeed even if the happy-path
+        # imports failed (e.g. syntax error in orchestrator); re-import
+        # defensively here.
+        try:
+            from libs.copilot.wiki_background import (  # noqa: PLC0415
+                write_last_refresh as _write_last_refresh,
+            )
+
+            _write_last_refresh(
+                root,
+                exit_code=exit_code,
+                modules_updated=modules_updated,
+                elapsed_seconds=max(0.0, time.time() - started_at),
+            )
+        except Exception:  # pragma: no cover — best-effort persistence
+            log.error("failed to write .refresh.last:\n%s", traceback.format_exc())
         _clear_lock(root)
     return exit_code
 

--- a/libs/copilot/models.py
+++ b/libs/copilot/models.py
@@ -90,6 +90,32 @@ class CopilotCheckReport(BaseModel):
             "can target it). None when no refresh is running."
         ),
     )
+    wiki_last_refresh_completed_at: float | None = Field(
+        default=None,
+        description=(
+            "Unix timestamp when the most recent background refresh finished, "
+            "regardless of outcome. None until at least one refresh has completed."
+        ),
+    )
+    wiki_last_refresh_exit_code: int | None = Field(
+        default=None,
+        description=(
+            "Exit code of the most recent background refresh. 0 = clean; "
+            "143 = SIGTERM (cancel via `ctx project wiki --stop`); anything else = crash. "
+            "None when no refresh has ever run."
+        ),
+    )
+    wiki_last_refresh_modules_updated: int | None = Field(
+        default=None,
+        description=(
+            "Modules touched by the most recent background refresh. For crashes this "
+            "reflects the last progress checkpoint, not the intended total."
+        ),
+    )
+    wiki_last_refresh_elapsed_seconds: float | None = Field(
+        default=None,
+        description="Wall-clock duration of the most recent background refresh.",
+    )
     qdrant_enabled: bool = Field(
         description="cfg.qdrant.enabled — vector retrieval availability flag"
     )

--- a/libs/copilot/orchestrator.py
+++ b/libs/copilot/orchestrator.py
@@ -141,6 +141,7 @@ def check_project(
     if not qdrant_enabled:
         degraded.append(DegradedMode.QDRANT_OFF)
 
+    last_run = bg_status.last_run
     return CopilotCheckReport(
         project_root=str(root),
         project_name=_project_name(root),
@@ -158,6 +159,14 @@ def check_project(
         wiki_refresh_modules_done=(bg_status.modules_done if bg_status.in_progress else 0),
         wiki_refresh_current_module=(bg_status.current_module if bg_status.in_progress else None),
         wiki_refresh_pid=bg_status.pid if bg_status.in_progress else None,
+        wiki_last_refresh_completed_at=(last_run.completed_at if last_run is not None else None),
+        wiki_last_refresh_exit_code=(last_run.exit_code if last_run is not None else None),
+        wiki_last_refresh_modules_updated=(
+            last_run.modules_updated if last_run is not None else None
+        ),
+        wiki_last_refresh_elapsed_seconds=(
+            last_run.elapsed_seconds if last_run is not None else None
+        ),
         qdrant_enabled=qdrant_enabled,
         degraded_modes=degraded,
     )

--- a/libs/copilot/wiki_background.py
+++ b/libs/copilot/wiki_background.py
@@ -49,6 +49,7 @@ log = logging.getLogger(__name__)
 
 LOCK_FILENAME = ".refresh.lock"
 LOG_FILENAME = ".refresh.log"
+LAST_REFRESH_FILENAME = ".refresh.last"
 _STALE_LOCK_AFTER_SECONDS = 60 * 60  # 1h ceiling for a single wiki refresh
 
 # Canonical phase labels emitted by the runner.
@@ -56,6 +57,24 @@ PHASE_STARTING = "starting"
 PHASE_LOADING = "loading"
 PHASE_GENERATING = "generating"
 PHASE_FINALIZING = "finalizing"
+
+
+@dataclass(frozen=True, slots=True)
+class LastRefreshRecord:
+    """Outcome of the most recent background refresh.
+
+    Written by the runner's ``finally`` block so it captures all three
+    exit shapes: clean completion (``exit_code == 0``), SIGTERM
+    cancellation (``exit_code == 143``), and crashes (any other
+    non-zero). ``modules_updated`` is the count the runner got through
+    before it exited — for crashes this may be less than
+    ``modules_total``.
+    """
+
+    completed_at: float
+    exit_code: int
+    modules_updated: int
+    elapsed_seconds: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,6 +90,7 @@ class BackgroundRefreshStatus:
     modules_total: int | None = None
     modules_done: int = 0
     current_module: str | None = None
+    last_run: LastRefreshRecord | None = None
 
 
 def _lock_path(root: Path) -> Path:
@@ -79,6 +99,10 @@ def _lock_path(root: Path) -> Path:
 
 def _log_path(root: Path) -> Path:
     return root / ".context" / "wiki" / LOG_FILENAME
+
+
+def _last_refresh_path(root: Path) -> Path:
+    return root / ".context" / "wiki" / LAST_REFRESH_FILENAME
 
 
 def _pid_alive(pid: int) -> bool:
@@ -100,6 +124,61 @@ def _atomic_write_lock(lock: Path, payload: dict[str, Any]) -> None:
     tmp.replace(lock)
 
 
+def write_last_refresh(
+    root: Path,
+    *,
+    exit_code: int,
+    modules_updated: int,
+    elapsed_seconds: float,
+    completed_at: float | None = None,
+) -> None:
+    """Persist the outcome of the most recent refresh to ``.refresh.last``.
+
+    Called from the runner's ``finally`` block so it captures clean
+    completion, SIGTERM cancellation, and crashes. Uses the same
+    write-then-rename pattern as the lock so a concurrent ``ctx project
+    check`` never sees a torn file.
+    """
+    path = _last_refresh_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "completed_at": float(completed_at if completed_at is not None else time.time()),
+        "exit_code": int(exit_code),
+        "modules_updated": int(modules_updated),
+        "elapsed_seconds": float(elapsed_seconds),
+    }
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    tmp.replace(path)
+
+
+def read_last_refresh(root: Path) -> LastRefreshRecord | None:
+    """Read ``.refresh.last`` if it exists. Returns ``None`` otherwise.
+
+    A corrupt file is treated the same as a missing one: we simply have
+    no record of the last run. That's a UX degradation, not a bug — the
+    next refresh rewrites the file.
+    """
+    path = _last_refresh_path(root)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        log.warning("wiki last-refresh record is corrupt at %s", path, exc_info=True)
+        return None
+    try:
+        return LastRefreshRecord(
+            completed_at=float(payload["completed_at"]),
+            exit_code=int(payload["exit_code"]),
+            modules_updated=int(payload["modules_updated"]),
+            elapsed_seconds=float(payload["elapsed_seconds"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        log.warning("wiki last-refresh record is malformed at %s", path, exc_info=True)
+        return None
+
+
 def read_status(root: Path) -> BackgroundRefreshStatus:
     """Inspect ``.context/wiki/.refresh.lock`` without mutating it.
 
@@ -110,15 +189,27 @@ def read_status(root: Path) -> BackgroundRefreshStatus:
     - lock is older than 1h (``stale=True``, zombie).
     """
     lock = _lock_path(root)
+    last_run = read_last_refresh(root)
     if not lock.exists():
-        return BackgroundRefreshStatus(in_progress=False, pid=None, started_at=None, lock_path=None)
+        return BackgroundRefreshStatus(
+            in_progress=False,
+            pid=None,
+            started_at=None,
+            lock_path=None,
+            last_run=last_run,
+        )
     try:
         payload = json.loads(lock.read_text(encoding="utf-8"))
     except Exception:
         # Corrupt lock → treat as stale; caller may choose to unlink.
         log.warning("wiki refresh lock is corrupt at %s", lock, exc_info=True)
         return BackgroundRefreshStatus(
-            in_progress=False, pid=None, started_at=None, lock_path=lock, stale=True
+            in_progress=False,
+            pid=None,
+            started_at=None,
+            lock_path=lock,
+            stale=True,
+            last_run=last_run,
         )
 
     pid = int(payload.get("pid", 0)) or None
@@ -143,6 +234,7 @@ def read_status(root: Path) -> BackgroundRefreshStatus:
         modules_total=modules_total,
         modules_done=modules_done,
         current_module=current_module,
+        last_run=last_run,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.3"
+version = "0.8.4"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/cli/test_project_cmd.py
+++ b/tests/unit/cli/test_project_cmd.py
@@ -382,3 +382,102 @@ def test_check_watch_polls_until_lock_disappears(
     assert 'generating 1/2 "libs/foo"' in result.stdout
     assert "bg_refresh=false" in result.stdout
     assert sleep_calls["n"] == 2
+
+
+# ---- _render_bg_refresh last-run formatting (v0.8.4) ----------------------
+
+
+def _minimal_report(**overrides: object):  # type: ignore[no-untyped-def]
+    """Build a minimal ``CopilotCheckReport`` for renderer unit tests.
+
+    Only the fields ``_render_bg_refresh`` consults are worth setting;
+    the rest take Pydantic defaults so the factory stays compact.
+    """
+    from libs.copilot import CopilotCheckReport
+
+    base: dict[str, object] = {
+        "project_root": "/tmp/p",
+        "project_name": "p",
+        "scanned": True,
+        "stale": False,
+        "wiki_present": True,
+        "qdrant_enabled": False,
+    }
+    base.update(overrides)
+    return CopilotCheckReport(**base)  # type: ignore[arg-type]
+
+
+def test_render_bg_refresh_idle_without_last_run_returns_false() -> None:
+    from apps.cli.commands.project_cmd import _render_bg_refresh
+
+    assert _render_bg_refresh(_minimal_report()) == "false"
+
+
+def test_render_bg_refresh_idle_with_clean_last_run() -> None:
+    import time as _time
+
+    from apps.cli.commands.project_cmd import _render_bg_refresh
+
+    now = _time.time()
+    report = _minimal_report(
+        wiki_last_refresh_completed_at=now - 200.0,
+        wiki_last_refresh_exit_code=0,
+        wiki_last_refresh_modules_updated=12,
+        wiki_last_refresh_elapsed_seconds=47.0,
+    )
+    rendered = _render_bg_refresh(report)
+    assert rendered.startswith("false (last: ok 12 modules 47s,")
+    assert "min ago" in rendered  # 200s → "3 min ago"
+
+
+def test_render_bg_refresh_idle_with_crashed_last_run() -> None:
+    import time as _time
+
+    from apps.cli.commands.project_cmd import _render_bg_refresh
+
+    now = _time.time()
+    report = _minimal_report(
+        wiki_last_refresh_completed_at=now - 5.0,
+        wiki_last_refresh_exit_code=1,
+        wiki_last_refresh_modules_updated=3,
+        wiki_last_refresh_elapsed_seconds=12.0,
+    )
+    rendered = _render_bg_refresh(report)
+    assert "FAILED exit=1" in rendered
+    assert "see .refresh.log" in rendered
+
+
+def test_render_bg_refresh_idle_with_sigterm_last_run() -> None:
+    import time as _time
+
+    from apps.cli.commands.project_cmd import _render_bg_refresh
+
+    now = _time.time()
+    report = _minimal_report(
+        wiki_last_refresh_completed_at=now - 5.0,
+        wiki_last_refresh_exit_code=143,
+        wiki_last_refresh_modules_updated=3,
+        wiki_last_refresh_elapsed_seconds=12.0,
+    )
+    rendered = _render_bg_refresh(report)
+    assert "cancelled after 3 modules 12s" in rendered
+
+
+def test_render_bg_refresh_running_ignores_last_run() -> None:
+    """While a refresh is in progress, we only show live progress."""
+    from apps.cli.commands.project_cmd import _render_bg_refresh
+
+    report = _minimal_report(
+        wiki_refresh_in_progress=True,
+        wiki_refresh_phase="generating",
+        wiki_refresh_modules_total=12,
+        wiki_refresh_modules_done=3,
+        wiki_refresh_pid=1234,
+        wiki_last_refresh_completed_at=1_700_000_000.0,
+        wiki_last_refresh_exit_code=1,
+        wiki_last_refresh_modules_updated=4,
+        wiki_last_refresh_elapsed_seconds=7.0,
+    )
+    rendered = _render_bg_refresh(report)
+    assert rendered.startswith("true (generating")
+    assert "last:" not in rendered  # live view supersedes the last-run hint

--- a/tests/unit/copilot/test_check_project.py
+++ b/tests/unit/copilot/test_check_project.py
@@ -281,3 +281,58 @@ def test_watch_rejects_too_small_interval(tmp_path: Path, qdrant_off_config: Pat
 
     with pytest.raises(ValueError, match="interval_seconds"):
         list(watch_check_project(tmp_path, interval_seconds=0.0))
+
+
+# ---- last-refresh record surfacing (v0.8.4) -------------------------------
+
+
+def test_check_surfaces_last_refresh_after_clean_run(
+    tmp_path: Path, qdrant_off_config: Path
+) -> None:
+    """When ``.refresh.last`` exists and no lock, last-run fields populate."""
+    from libs.copilot import write_last_refresh
+
+    _make_project(tmp_path)
+    (tmp_path / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+    write_last_refresh(
+        tmp_path,
+        exit_code=0,
+        modules_updated=5,
+        elapsed_seconds=8.25,
+        completed_at=1_700_000_000.0,
+    )
+    report = check_project(tmp_path)
+    assert report.wiki_refresh_in_progress is False
+    assert report.wiki_last_refresh_completed_at == pytest.approx(1_700_000_000.0)
+    assert report.wiki_last_refresh_exit_code == 0
+    assert report.wiki_last_refresh_modules_updated == 5
+    assert report.wiki_last_refresh_elapsed_seconds == pytest.approx(8.25)
+
+
+def test_check_surfaces_last_refresh_crash(tmp_path: Path, qdrant_off_config: Path) -> None:
+    """A non-zero exit_code makes it to the report unchanged."""
+    from libs.copilot import write_last_refresh
+
+    _make_project(tmp_path)
+    (tmp_path / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+    write_last_refresh(
+        tmp_path,
+        exit_code=1,
+        modules_updated=2,
+        elapsed_seconds=0.5,
+        completed_at=1_700_000_000.0,
+    )
+    report = check_project(tmp_path)
+    assert report.wiki_last_refresh_exit_code == 1
+    assert report.wiki_last_refresh_modules_updated == 2
+
+
+def test_check_last_refresh_fields_none_when_never_run(
+    tmp_path: Path, qdrant_off_config: Path
+) -> None:
+    _make_project(tmp_path)
+    report = check_project(tmp_path)
+    assert report.wiki_last_refresh_completed_at is None
+    assert report.wiki_last_refresh_exit_code is None
+    assert report.wiki_last_refresh_modules_updated is None
+    assert report.wiki_last_refresh_elapsed_seconds is None

--- a/tests/unit/copilot/test_wiki_background.py
+++ b/tests/unit/copilot/test_wiki_background.py
@@ -282,3 +282,76 @@ def test_cancel_clears_stale_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     status = wiki_background.cancel_background_refresh(tmp_path)
     assert status.stale is True
     assert not lock.exists()
+
+
+# ---- last-refresh record (v0.8.4) -----------------------------------------
+
+
+def test_read_last_refresh_returns_none_when_file_absent(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    assert wiki_background.read_last_refresh(tmp_path) is None
+
+
+def test_write_then_read_last_refresh_round_trips(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    wiki_background.write_last_refresh(
+        tmp_path,
+        exit_code=0,
+        modules_updated=7,
+        elapsed_seconds=12.5,
+        completed_at=1_700_000_000.0,
+    )
+    record = wiki_background.read_last_refresh(tmp_path)
+    assert record is not None
+    assert record.exit_code == 0
+    assert record.modules_updated == 7
+    assert record.elapsed_seconds == pytest.approx(12.5)
+    assert record.completed_at == pytest.approx(1_700_000_000.0)
+
+
+def test_read_last_refresh_handles_corrupt_file(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    (tmp_path / ".context" / "wiki" / ".refresh.last").write_text("{not json", encoding="utf-8")
+    assert wiki_background.read_last_refresh(tmp_path) is None
+
+
+def test_read_last_refresh_handles_missing_keys(tmp_path: Path) -> None:
+    """A valid JSON object missing required keys falls back to None.
+
+    Forward compatibility: a future schema version with renamed keys
+    shouldn't crash older readers.
+    """
+    _make_project(tmp_path)
+    (tmp_path / ".context" / "wiki" / ".refresh.last").write_text(
+        json.dumps({"completed_at": 1.0, "exit_code": 0}),  # missing two keys
+        encoding="utf-8",
+    )
+    assert wiki_background.read_last_refresh(tmp_path) is None
+
+
+def test_read_status_surfaces_last_run(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    wiki_background.write_last_refresh(
+        tmp_path,
+        exit_code=1,
+        modules_updated=4,
+        elapsed_seconds=3.2,
+        completed_at=1_700_000_000.0,
+    )
+    status = wiki_background.read_status(tmp_path)
+    assert status.in_progress is False
+    assert status.last_run is not None
+    assert status.last_run.exit_code == 1
+    assert status.last_run.modules_updated == 4
+
+
+def test_write_last_refresh_is_atomic_via_rename(tmp_path: Path) -> None:
+    """No ``.tmp`` sibling should survive after a successful write."""
+    _make_project(tmp_path)
+    wiki_background.write_last_refresh(
+        tmp_path, exit_code=0, modules_updated=1, elapsed_seconds=0.5
+    )
+    wiki_dir = tmp_path / ".context" / "wiki"
+    tmp_siblings = list(wiki_dir.glob(".refresh.last.tmp*"))
+    assert tmp_siblings == []
+    assert (wiki_dir / ".refresh.last").exists()

--- a/tests/unit/copilot/test_wiki_bg_runner.py
+++ b/tests/unit/copilot/test_wiki_bg_runner.py
@@ -1,0 +1,108 @@
+"""Tests for ``libs.copilot._wiki_bg_runner`` — the detached runner.
+
+These tests drive ``main()`` directly (no subprocess) and assert that
+``.refresh.last`` is persisted on three exit shapes: clean success,
+SIGTERM cancellation, and crash. Deferred imports inside ``main`` are
+monkeypatched at the module they're resolved at: ``libs.copilot.orchestrator``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from libs.copilot import _wiki_bg_runner, wiki_background
+
+
+def _make_project(root: Path) -> None:
+    (root / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+
+
+def _install_fake_orchestrator(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fake: Callable[..., Any],
+) -> None:
+    """Swap in ``_run_wiki_update_in_process`` so main() doesn't import the real stack."""
+    import libs.copilot.orchestrator as orch
+
+    monkeypatch.setattr(orch, "_run_wiki_update_in_process", fake)
+
+
+def test_runner_writes_last_refresh_on_clean_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_project(tmp_path)
+
+    def fake_update(
+        _root: Path,
+        *,
+        all_modules: bool,
+        on_progress: Callable[..., None],
+    ) -> tuple[int, list[str]]:
+        on_progress(done=2, total=2, current="pkg/a")
+        return (2, [])
+
+    _install_fake_orchestrator(monkeypatch, fake=fake_update)
+    exit_code = _wiki_bg_runner.main([str(tmp_path)])
+    assert exit_code == 0
+
+    record = wiki_background.read_last_refresh(tmp_path)
+    assert record is not None
+    assert record.exit_code == 0
+    assert record.modules_updated == 2
+    assert record.elapsed_seconds >= 0.0
+
+
+def test_runner_writes_last_refresh_on_sigterm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SIGTERM path: ``SystemExit`` from inside update still flows through finally."""
+    _make_project(tmp_path)
+
+    def fake_update(
+        _root: Path,
+        *,
+        all_modules: bool,
+        on_progress: Callable[..., None],
+    ) -> tuple[int, list[str]]:
+        on_progress(done=1, total=5, current="pkg/a")
+        # Simulate SIGTERM mid-run — main() maps this to exit_code=143.
+        raise SystemExit(143)
+
+    _install_fake_orchestrator(monkeypatch, fake=fake_update)
+    exit_code = _wiki_bg_runner.main([str(tmp_path)])
+    assert exit_code == 143
+
+    record = wiki_background.read_last_refresh(tmp_path)
+    assert record is not None
+    assert record.exit_code == 143
+    # The on_progress callback ran once before the SystemExit, so the
+    # last observed count (1) is what the record should reflect.
+    assert record.modules_updated == 1
+
+
+def test_runner_writes_last_refresh_on_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unexpected exception → exit_code=1 and ``.refresh.last`` still persists."""
+    _make_project(tmp_path)
+
+    def fake_update(
+        _root: Path,
+        *,
+        all_modules: bool,
+        on_progress: Callable[..., None],
+    ) -> tuple[int, list[str]]:
+        raise RuntimeError("boom")
+
+    _install_fake_orchestrator(monkeypatch, fake=fake_update)
+    exit_code = _wiki_bg_runner.main([str(tmp_path)])
+    assert exit_code == 1
+
+    record = wiki_background.read_last_refresh(tmp_path)
+    assert record is not None
+    assert record.exit_code == 1
+    assert record.modules_updated == 0

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "lv-dcp"
-version = "0.8.3"
+version = "0.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Runner writes `.context/wiki/.refresh.last` in its `finally` block with `{completed_at, exit_code, modules_updated, elapsed_seconds}` — covers clean, SIGTERM, and crash exits.
- `ctx project check` surfaces the record: `bg_refresh=false (last: ok 12 modules 47s, 3 min ago)` / `FAILED exit=1 … — see .refresh.log` / `cancelled after 3 modules 12s, 3 min ago`.
- New library primitives: `LastRefreshRecord`, `write_last_refresh`, `read_last_refresh`; `BackgroundRefreshStatus.last_run` field; four `CopilotCheckReport` fields (all `Optional` — backwards-compat).
- Closes v0.8.3's *"No transition-to-error surface"* Known gap.

## Test plan
- [x] **+17 tests**, total suite 1118 passing (+17 vs v0.8.3).
- [x] Runner tests cover clean / SIGTERM / crash paths writing `.refresh.last`.
- [x] CLI renderer unit tests cover the four shapes (idle-no-record, ok, cancelled, FAILED).
- [x] `check_project` unit tests confirm fields surface correctly and default to `None` when never run.
- [x] Ruff + mypy clean (`make lint` / `make typecheck`).
- [x] No new deps, no DB migration, no new process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)