### PR TITLE
release(v0.8.5): error log tail in .refresh.last

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.4-last-refresh.md)
-[![Version 0.8.4](https://img.shields.io/badge/version-0.8.4-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.5-log-tail.md)
+[![Version 0.8.5](https://img.shields.io/badge/version-0.8.5-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.5 (2026-04-24)** — Error log tail. On a non-clean, non-SIGTERM exit the runner seeks past its startup offset in `.refresh.log` and persists the current run's last ~20 lines as `log_tail` in `.refresh.last`. `ctx project check` renders them as an indented `log tail:` block under the `FAILED exit=…` last-run hint, so diagnosing a crashed refresh no longer requires a second `cat .refresh.log` step. Suppressed on clean / SIGTERM exits and while a refresh is in progress. Closes the *"No error-tail surface"* gap from v0.8.4. No new deps.
+
 **v0.8.4 (2026-04-24)** — `.refresh.last` outcome record. After every background wiki refresh finishes (cleanly, via SIGTERM, or crash), the runner's `finally` block writes `.context/wiki/.refresh.last` with `{completed_at, exit_code, modules_updated, elapsed_seconds}`. `ctx project check` then renders `bg_refresh=false (last: ok 12 modules 47s, 3 min ago)` — or `FAILED exit=1 … — see .refresh.log` for crashes. Closes the *"No transition-to-error surface"* gap from v0.8.3: the watcher now tells you *why* the refresh stopped, not just *that* it stopped. No new deps, no new process.
 
 **v0.8.3 (2026-04-24)** — `ctx project check --watch`. Live-tail the background wiki refresh: re-prints the full `check` snapshot every `--interval` seconds (default 2 s) until the refresh transitions to idle, then exits. `--json` mode streams consecutive `CopilotCheckReport` objects separated by blank lines — grep- and `jq -c`-friendly. Closes the *"No live tail"* gap from v0.8.2. No new deps; generator-based polling, not threads.
@@ -74,6 +76,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.5-log-tail.md](docs/release/2026-04-24-v0.8.5-log-tail.md) (v0.8.5 — Error log tail)
 - [docs/release/2026-04-24-v0.8.4-last-refresh.md](docs/release/2026-04-24-v0.8.4-last-refresh.md) (v0.8.4 — `.refresh.last` outcome record)
 - [docs/release/2026-04-24-v0.8.3-check-watch.md](docs/release/2026-04-24-v0.8.3-check-watch.md) (v0.8.3 — `ctx project check --watch`)
 - [docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md](docs/release/2026-04-24-v0.8.2-wiki-progress-cancel.md) (v0.8.2 — Wiki Background Progress & Cancellation)
@@ -430,6 +433,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.2** (done) — Wiki background progress + cancellation. Lock payload carries `phase` / `modules_total`/`_done` / `current_module`; `ctx project check` renders `bg_refresh=true (generating 3/12 "libs/foo" pid=1234)`. New `--stop` flag sends SIGTERM and cleans up stale locks. Closes both known gaps from v0.8.1. No new deps.
 - **v0.8.3** (done) — `ctx project check --watch`: generator-based live-tail that polls the lock and re-prints the snapshot until the refresh settles. `--json` mode streams consecutive reports separated by blank lines. Closes the "no live tail" gap from v0.8.2. No threads, no new deps.
 - **v0.8.4** (done) — `.refresh.last` outcome record: the runner writes `{completed_at, exit_code, modules_updated, elapsed_seconds}` in its `finally` block (clean / SIGTERM / crash all covered), and `ctx project check` renders `bg_refresh=false (last: ok 12 modules 47s, 3 min ago)` or `FAILED exit=1 … — see .refresh.log`. Closes the "no transition-to-error surface" gap from v0.8.3. No new deps, no new process.
+- **v0.8.5** (done) — Error log tail: on a non-clean, non-SIGTERM exit the runner captures the current run's last ~20 lines of `.refresh.log` into `.refresh.last.log_tail`, and `ctx project check` renders them as an indented block under the `FAILED exit=…` last-run hint — so diagnosing a crashed refresh no longer needs a second `cat .refresh.log`. Closes the "no error-tail surface" gap from v0.8.4. No new deps.
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/cli/commands/project_cmd.py
+++ b/apps/cli/commands/project_cmd.py
@@ -126,6 +126,18 @@ def _render_check(report: CopilotCheckReport, *, as_json: bool) -> str:
         f"dirty_modules={report.wiki_dirty_modules} "
         f"bg_refresh={bg_label}"
     )
+    # Surface the crash log tail only when a FAILED run has been
+    # recorded AND no new refresh is in progress (we don't want the
+    # old tail competing with the live progress line). Clean runs and
+    # SIGTERM cancellations are self-explanatory from bg_label alone.
+    if (
+        not report.wiki_refresh_in_progress
+        and report.wiki_last_refresh_log_tail
+        and report.wiki_last_refresh_exit_code not in (None, 0, _SIGTERM_EXIT_CODE)
+    ):
+        lines.append("    log tail:")
+        for line in report.wiki_last_refresh_log_tail:
+            lines.append(f"      {line}")
     lines.append(f"  qdrant enabled:  {report.qdrant_enabled}")
     if report.degraded_modes:
         lines.append("  degraded modes:")

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -22,7 +22,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.4</span>
+        <span>LV_DCP Dashboard &bull; v0.8.5</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.5-log-tail.md
+++ b/docs/release/2026-04-24-v0.8.5-log-tail.md
@@ -1,0 +1,158 @@
+# LV_DCP v0.8.5 — Error log tail
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** close the *"No error-tail surface"* Known gap from v0.8.4 —
+when a background wiki refresh crashes, the runner now captures the
+last ~20 lines of `.refresh.log` into `.refresh.last`, and `ctx project
+check` renders the tail inline so diagnosing a failure no longer needs
+a second `cat .refresh.log` step.
+
+## Why
+
+v0.8.4 told the user *that* a refresh failed:
+
+```
+bg_refresh=false (last: FAILED exit=1 after 8 modules 12s, 3 min ago — see .refresh.log)
+```
+
+…but still forced a manual `tail -n 20 .context/wiki/.refresh.log` to
+learn *why*. For CI contexts and watcher-style UIs that show only
+`ctx project check --json`, even that manual step is awkward: the log
+file belongs to the runner, not the query tool.
+
+v0.8.5 closes the loop. On a non-clean, non-SIGTERM exit the runner
+seeks to its startup offset in `.refresh.log`, grabs the tail of what
+*this run* wrote, and persists it as `log_tail: list[str]` in
+`.refresh.last`. `check_project` surfaces the list on
+`CopilotCheckReport.wiki_last_refresh_log_tail`, and the CLI renders it
+as an indented block under the `FAILED` last-run hint.
+
+## Shipped
+
+### Log-tail capture (`libs/copilot/_wiki_bg_runner.py`)
+
+`.refresh.log` is append-only across runs (the parent opens it with
+`>>` semantics), so the tail must be scoped to the *current* run:
+
+1. `_initial_log_offset(root)` snapshots `path.stat().st_size` at
+   runner startup, *before* the first `log.info(...)` line;
+2. in the `finally` block, when `exit_code not in (0, 143)`,
+   `_capture_log_tail(root, start_offset=…)` seeks past the offset,
+   flushes pending stdout/stderr writes, splits on newlines, strips
+   blanks, and returns up to 200 non-empty tail lines (the
+   persistence layer caps at 20 at write time).
+
+Any read error returns `None` — the log tail is best-effort
+diagnostics, never a failure mode for the runner itself.
+
+### `.refresh.last` schema extension
+
+```python
+@dataclass(frozen=True)
+class LastRefreshRecord:
+    ...
+    log_tail: tuple[str, ...] | None = None   # new in v0.8.5
+```
+
+Written only when non-empty and only on crashes; absent key → `None` on
+read. Cap: `_MAX_LOG_TAIL_LINES = 20`. Existing JSON consumers are
+unaffected — `log_tail` is optional both in the payload and in the
+dataclass.
+
+```python
+write_last_refresh(
+    root,
+    exit_code=1,
+    modules_updated=4,
+    elapsed_seconds=12.0,
+    log_tail=[
+        "2026-04-24 [bg-wiki pid=1] Traceback (most recent call last):",
+        '  File "orchestrator.py", line 210, in _run_wiki_update_in_process',
+        "RuntimeError: 'pkg/foo' is not a valid module path",
+    ],
+)
+```
+
+### `CopilotCheckReport` surface
+
+One new field, same nullability contract as v0.8.4's four:
+
+| field                         | meaning                                               |
+|-------------------------------|-------------------------------------------------------|
+| `wiki_last_refresh_log_tail`  | list of recent `.refresh.log` lines on crash, or None |
+
+`None` for clean (`exit_code=0`) and cancelled (`exit_code=143`) runs,
+as well as when no refresh has ever happened.
+
+### CLI rendering
+
+When the last run failed, `ctx project check` now prints the tail
+inline, indented under the `bg_refresh` line:
+
+```
+$ ctx project check .
+project: LV_DCP  (/Users/me/src/LV_DCP)
+  wiki:            present=True dirty_modules=0 bg_refresh=false (last: FAILED exit=1 after 4 modules 12s, 3 min ago — see .refresh.log)
+    log tail:
+      2026-04-24 [bg-wiki pid=1] Traceback (most recent call last):
+        File "orchestrator.py", line 210, in _run_wiki_update_in_process
+      RuntimeError: 'pkg/foo' is not a valid module path
+```
+
+The block is suppressed when a refresh is in progress (the live
+progress line supersedes it), and on clean / SIGTERM exits (the
+`FAILED` label isn't present, so there's nothing to explain).
+
+## Tests
+
+- **+4** in `tests/unit/copilot/test_wiki_background.py`: `log_tail`
+  round-trip, 20-line cap at write time, omission when empty, tolerance
+  for malformed `log_tail` values in the JSON payload.
+- **+3** in `tests/unit/copilot/test_wiki_bg_runner.py`: runner
+  captures tail on crash (offset filtering verified with pre-run noise
+  that must not leak), `None` on clean exit, `None` on SIGTERM.
+- **+2** in `tests/unit/copilot/test_check_project.py`: report surfaces
+  `log_tail` on crash, suppresses it on clean runs.
+- **+3** in `tests/unit/cli/test_project_cmd.py`: CLI renders the
+  indented `log tail:` block on FAILED last-run, suppresses it on
+  clean, suppresses it on SIGTERM.
+- **Total suite: 1130 passing (+12 vs v0.8.4).** Ruff + mypy clean.
+
+## Design notes
+
+- **Offset-based slicing.** File offsets beat `seek(0); readlines()[-N:]`
+  when log files cross runs, because the latter would leak previous
+  crashes into the current record. The startup offset is captured *before*
+  the runner writes its own `start root=… all_modules=…` line so the
+  tail never elides "our own" first few lines.
+- **Cap applied at the persistence layer.** The runner reads up to 200
+  lines and passes them to `write_last_refresh`, which trims to 20.
+  That lets us raise the display cap later without touching the runner.
+- **Tuple in the dataclass, list on the wire.** `LastRefreshRecord` is
+  frozen, so the tail is a `tuple[str, ...]` for immutability; the JSON
+  payload stores a list and `read_last_refresh` re-tuples on load.
+- **Best-effort everywhere.** A missing log file, a read error, an
+  encoding surprise — all silently return `None`. The log tail is a
+  diagnostic affordance, not a correctness guarantee.
+
+## Migration / compat
+
+- `.context/wiki/.refresh.last` records written by v0.8.4 have no
+  `log_tail` key. v0.8.5 treats missing / malformed values as `None`,
+  so old records surface unchanged.
+- `CopilotCheckReport.wiki_last_refresh_log_tail` defaults to `None`;
+  JSON consumers must treat it as optional.
+- No new deps, no DB migration, no config knob.
+
+## Known gaps (carry-forward)
+
+- **Tail is a flat string list.** We don't parse timestamps, log
+  levels, or frame lines — the user sees raw `.refresh.log` output.
+  For most crashes that's exactly what the user would `cat` by hand, so
+  not a pressing gap; a future release could add a structured
+  `last_error: {exc_type, message, frames: [...]}` surface if the UI
+  ever wants to linkify stack frames.
+- **No retry / auto-heal.** A crashed refresh is now fully reported
+  (exit code + tail), but still not retried. The user still has to run
+  `ctx project refresh --wiki-background` manually.

--- a/libs/copilot/_wiki_bg_runner.py
+++ b/libs/copilot/_wiki_bg_runner.py
@@ -30,9 +30,66 @@ import traceback
 from pathlib import Path
 from types import FrameType
 
+#: Maximum number of ``.refresh.log`` lines returned to the writer. The
+#: persistence layer applies its own cap via ``_MAX_LOG_TAIL_LINES``; we
+#: use a generous multiple here so we can discard blank/boilerplate lines
+#: during post-processing without risking truncation of useful context.
+_LOG_TAIL_READ_CAP = 200
+
 
 def _lock_path(root: Path) -> Path:
     return root / ".context" / "wiki" / ".refresh.lock"
+
+
+def _log_path(root: Path) -> Path:
+    return root / ".context" / "wiki" / ".refresh.log"
+
+
+def _initial_log_offset(root: Path) -> int:
+    """Byte offset in ``.refresh.log`` at runner startup.
+
+    The parent redirects stdout/stderr of the runner into this file via
+    ``>>`` semantics (``open("ab")``), so earlier runs' lines are still
+    present. We remember the starting size so a post-mortem tail only
+    surfaces lines from *this* run.
+    """
+    path = _log_path(root)
+    try:
+        return path.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+def _capture_log_tail(
+    root: Path, *, start_offset: int, max_lines: int = _LOG_TAIL_READ_CAP
+) -> list[str] | None:
+    """Return the last ``max_lines`` of ``.refresh.log`` since ``start_offset``.
+
+    Returns ``None`` when the log file doesn't exist (e.g. unit-test
+    environments that don't spawn a real subprocess with stdout
+    redirection). Any read error also returns ``None`` — this is a
+    best-effort diagnostic, never a failure mode for the runner.
+    """
+    path = _log_path(root)
+    try:
+        # Flush any pending logging-handler writes before tailing.
+        for stream in (sys.stdout, sys.stderr):
+            with contextlib.suppress(Exception):  # pragma: no cover — best-effort
+                stream.flush()
+        with path.open("rb") as fh:
+            fh.seek(start_offset)
+            raw = fh.read()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+    if not raw:
+        return None
+    text = raw.decode("utf-8", errors="replace")
+    lines = [line.rstrip("\r") for line in text.split("\n") if line.strip()]
+    if not lines:
+        return None
+    return lines[-max_lines:]
 
 
 def _write_initial_lock(root: Path, *, all_modules: bool) -> None:
@@ -87,6 +144,10 @@ def main(argv: list[str] | None = None) -> int:
 
     _write_initial_lock(root, all_modules=args.all_modules)
     _install_sigterm_handler()
+    # Capture the log file size *before* our first log line so the
+    # post-mortem tail only includes output from this run (``.refresh.log``
+    # is append-only and accumulates across refreshes).
+    log_start_offset = _initial_log_offset(root)
     log.info("start root=%s all_modules=%s", root, args.all_modules)
     exit_code = 0
     # ``modules_updated`` reflects modules actually refreshed before exit.
@@ -146,11 +207,20 @@ def main(argv: list[str] | None = None) -> int:
                 write_last_refresh as _write_last_refresh,
             )
 
+            # Only capture the log tail on crashes. Clean exit (0) and
+            # SIGTERM (143) don't need it — the user gets a successful
+            # summary or an explicit "cancelled" label instead, and an
+            # unused log tail just bloats the record.
+            log_tail: list[str] | None = None
+            if exit_code not in (0, 143):
+                log_tail = _capture_log_tail(root, start_offset=log_start_offset)
+
             _write_last_refresh(
                 root,
                 exit_code=exit_code,
                 modules_updated=modules_updated,
                 elapsed_seconds=max(0.0, time.time() - started_at),
+                log_tail=log_tail,
             )
         except Exception:  # pragma: no cover — best-effort persistence
             log.error("failed to write .refresh.last:\n%s", traceback.format_exc())

--- a/libs/copilot/models.py
+++ b/libs/copilot/models.py
@@ -116,6 +116,14 @@ class CopilotCheckReport(BaseModel):
         default=None,
         description="Wall-clock duration of the most recent background refresh.",
     )
+    wiki_last_refresh_log_tail: list[str] | None = Field(
+        default=None,
+        description=(
+            "Last ~20 lines of ``.refresh.log`` captured at runner exit, populated "
+            "only when the most recent refresh crashed (non-zero, non-SIGTERM exit). "
+            "None for clean / cancelled runs and when no refresh has ever happened."
+        ),
+    )
     qdrant_enabled: bool = Field(
         description="cfg.qdrant.enabled — vector retrieval availability flag"
     )

--- a/libs/copilot/orchestrator.py
+++ b/libs/copilot/orchestrator.py
@@ -167,6 +167,11 @@ def check_project(
         wiki_last_refresh_elapsed_seconds=(
             last_run.elapsed_seconds if last_run is not None else None
         ),
+        wiki_last_refresh_log_tail=(
+            list(last_run.log_tail)
+            if (last_run is not None and last_run.log_tail is not None)
+            else None
+        ),
         qdrant_enabled=qdrant_enabled,
         degraded_modes=degraded,
     )

--- a/libs/copilot/wiki_background.py
+++ b/libs/copilot/wiki_background.py
@@ -40,6 +40,7 @@ import signal
 import subprocess
 import sys
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,11 @@ LOCK_FILENAME = ".refresh.lock"
 LOG_FILENAME = ".refresh.log"
 LAST_REFRESH_FILENAME = ".refresh.last"
 _STALE_LOCK_AFTER_SECONDS = 60 * 60  # 1h ceiling for a single wiki refresh
+
+#: Maximum number of log lines persisted into ``.refresh.last``. Bounded
+#: to keep the record small (it's read on every ``ctx project check``)
+#: while still carrying enough context to triage a crash.
+_MAX_LOG_TAIL_LINES = 20
 
 # Canonical phase labels emitted by the runner.
 PHASE_STARTING = "starting"
@@ -69,12 +75,18 @@ class LastRefreshRecord:
     non-zero). ``modules_updated`` is the count the runner got through
     before it exited — for crashes this may be less than
     ``modules_total``.
+
+    ``log_tail`` is populated only on crash (non-zero, non-SIGTERM).
+    It carries the last ~20 lines of ``.refresh.log`` as captured at
+    runner exit time — self-contained so the user can diagnose without
+    re-reading the log file (which accumulates across runs).
     """
 
     completed_at: float
     exit_code: int
     modules_updated: int
     elapsed_seconds: float
+    log_tail: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,13 +136,14 @@ def _atomic_write_lock(lock: Path, payload: dict[str, Any]) -> None:
     tmp.replace(lock)
 
 
-def write_last_refresh(
+def write_last_refresh(  # noqa: PLR0913 — kw-only payload fields; constructor-style
     root: Path,
     *,
     exit_code: int,
     modules_updated: int,
     elapsed_seconds: float,
     completed_at: float | None = None,
+    log_tail: Sequence[str] | None = None,
 ) -> None:
     """Persist the outcome of the most recent refresh to ``.refresh.last``.
 
@@ -138,15 +151,22 @@ def write_last_refresh(
     completion, SIGTERM cancellation, and crashes. Uses the same
     write-then-rename pattern as the lock so a concurrent ``ctx project
     check`` never sees a torn file.
+
+    ``log_tail`` is truncated to the last :data:`_MAX_LOG_TAIL_LINES`
+    entries before persistence; callers can pass a larger list and rely
+    on the bound.
     """
     path = _last_refresh_path(root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
+    payload: dict[str, Any] = {
         "completed_at": float(completed_at if completed_at is not None else time.time()),
         "exit_code": int(exit_code),
         "modules_updated": int(modules_updated),
         "elapsed_seconds": float(elapsed_seconds),
     }
+    if log_tail:
+        trimmed = [str(line) for line in list(log_tail)[-_MAX_LOG_TAIL_LINES:]]
+        payload["log_tail"] = trimmed
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(payload), encoding="utf-8")
     tmp.replace(path)
@@ -168,11 +188,16 @@ def read_last_refresh(root: Path) -> LastRefreshRecord | None:
         log.warning("wiki last-refresh record is corrupt at %s", path, exc_info=True)
         return None
     try:
+        raw_tail = payload.get("log_tail")
+        log_tail: tuple[str, ...] | None = None
+        if isinstance(raw_tail, list) and raw_tail:
+            log_tail = tuple(str(line) for line in raw_tail)
         return LastRefreshRecord(
             completed_at=float(payload["completed_at"]),
             exit_code=int(payload["exit_code"]),
             modules_updated=int(payload["modules_updated"]),
             elapsed_seconds=float(payload["elapsed_seconds"]),
+            log_tail=log_tail,
         )
     except (KeyError, TypeError, ValueError):
         log.warning("wiki last-refresh record is malformed at %s", path, exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.4"
+version = "0.8.5"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/cli/test_project_cmd.py
+++ b/tests/unit/cli/test_project_cmd.py
@@ -481,3 +481,83 @@ def test_render_bg_refresh_running_ignores_last_run() -> None:
     rendered = _render_bg_refresh(report)
     assert rendered.startswith("true (generating")
     assert "last:" not in rendered  # live view supersedes the last-run hint
+
+
+# ---- log tail rendering (v0.8.5) ------------------------------------------
+
+
+def test_check_renders_log_tail_on_failed_run(tmp_path: Path) -> None:
+    """A crashed last-run surfaces indented ``log tail:`` lines in ``ctx project check``."""
+    from libs.copilot import write_last_refresh
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _seed_project(proj)
+    scan_project(proj, mode="full")
+    (proj / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+    write_last_refresh(
+        proj,
+        exit_code=1,
+        modules_updated=2,
+        elapsed_seconds=1.5,
+        log_tail=[
+            "Traceback (most recent call last):",
+            '  File "x.py", line 10, in _run',
+            "RuntimeError: boom",
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["project", "check", str(proj)])
+    assert result.exit_code == 0, result.stdout
+    assert "FAILED exit=1" in result.stdout
+    assert "log tail:" in result.stdout
+    assert "RuntimeError: boom" in result.stdout
+
+
+def test_check_does_not_render_log_tail_on_clean_run(tmp_path: Path) -> None:
+    """Clean last-run → no ``log tail:`` block even if someone persisted one."""
+    from libs.copilot import write_last_refresh
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _seed_project(proj)
+    scan_project(proj, mode="full")
+    (proj / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+    write_last_refresh(
+        proj,
+        exit_code=0,
+        modules_updated=3,
+        elapsed_seconds=2.0,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["project", "check", str(proj)])
+    assert result.exit_code == 0, result.stdout
+    assert "log tail:" not in result.stdout
+
+
+def test_check_does_not_render_log_tail_on_sigterm(tmp_path: Path) -> None:
+    """SIGTERM last-run → no ``log tail:`` block (cancel label suffices)."""
+    from libs.copilot import write_last_refresh
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _seed_project(proj)
+    scan_project(proj, mode="full")
+    (proj / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+    # A SIGTERM path shouldn't have persisted a tail, but even if one snuck
+    # through, the renderer suppresses it.
+    write_last_refresh(
+        proj,
+        exit_code=143,
+        modules_updated=1,
+        elapsed_seconds=0.5,
+        log_tail=["something that should not render"],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["project", "check", str(proj)])
+    assert result.exit_code == 0, result.stdout
+    assert "cancelled" in result.stdout
+    assert "log tail:" not in result.stdout

--- a/tests/unit/copilot/test_check_project.py
+++ b/tests/unit/copilot/test_check_project.py
@@ -336,3 +336,48 @@ def test_check_last_refresh_fields_none_when_never_run(
     assert report.wiki_last_refresh_exit_code is None
     assert report.wiki_last_refresh_modules_updated is None
     assert report.wiki_last_refresh_elapsed_seconds is None
+    assert report.wiki_last_refresh_log_tail is None
+
+
+# ---- log_tail surfacing on crash (v0.8.5) ---------------------------------
+
+
+def test_check_surfaces_log_tail_on_crash(tmp_path: Path, qdrant_off_config: Path) -> None:
+    """A crashed run's ``log_tail`` flows into the report as a list."""
+    from libs.copilot import write_last_refresh
+
+    _make_project(tmp_path)
+    (tmp_path / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+    tail = [
+        "Traceback (most recent call last):",
+        '  File "x.py", line 10, in _run',
+        "RuntimeError: boom",
+    ]
+    write_last_refresh(
+        tmp_path,
+        exit_code=1,
+        modules_updated=2,
+        elapsed_seconds=0.5,
+        completed_at=1_700_000_000.0,
+        log_tail=tail,
+    )
+    report = check_project(tmp_path)
+    assert report.wiki_last_refresh_exit_code == 1
+    assert report.wiki_last_refresh_log_tail == tail
+
+
+def test_check_log_tail_none_when_clean_run(tmp_path: Path, qdrant_off_config: Path) -> None:
+    """Clean runs don't persist a tail → report field stays None."""
+    from libs.copilot import write_last_refresh
+
+    _make_project(tmp_path)
+    (tmp_path / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+    write_last_refresh(
+        tmp_path,
+        exit_code=0,
+        modules_updated=3,
+        elapsed_seconds=2.0,
+        completed_at=1_700_000_000.0,
+    )
+    report = check_project(tmp_path)
+    assert report.wiki_last_refresh_log_tail is None

--- a/tests/unit/copilot/test_wiki_background.py
+++ b/tests/unit/copilot/test_wiki_background.py
@@ -355,3 +355,69 @@ def test_write_last_refresh_is_atomic_via_rename(tmp_path: Path) -> None:
     tmp_siblings = list(wiki_dir.glob(".refresh.last.tmp*"))
     assert tmp_siblings == []
     assert (wiki_dir / ".refresh.last").exists()
+
+
+# ---- log_tail round-trip (v0.8.5) -----------------------------------------
+
+
+def test_last_refresh_log_tail_round_trips(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    lines = ["2026-04-24 [bg-wiki pid=42] start", "2026-04-24 [bg-wiki pid=42] boom"]
+    wiki_background.write_last_refresh(
+        tmp_path,
+        exit_code=1,
+        modules_updated=0,
+        elapsed_seconds=0.1,
+        log_tail=lines,
+    )
+    rec = wiki_background.read_last_refresh(tmp_path)
+    assert rec is not None
+    assert rec.log_tail == tuple(lines)
+
+
+def test_last_refresh_log_tail_is_truncated_to_cap(tmp_path: Path) -> None:
+    """A caller passing more than _MAX_LOG_TAIL_LINES gets the last N kept."""
+    _make_project(tmp_path)
+    big = [f"line {i}" for i in range(100)]
+    wiki_background.write_last_refresh(
+        tmp_path, exit_code=1, modules_updated=0, elapsed_seconds=0.0, log_tail=big
+    )
+    rec = wiki_background.read_last_refresh(tmp_path)
+    assert rec is not None
+    assert rec.log_tail is not None
+    assert len(rec.log_tail) == wiki_background._MAX_LOG_TAIL_LINES
+    # Tail end preserved, not the head.
+    assert rec.log_tail[-1] == "line 99"
+
+
+def test_last_refresh_log_tail_omitted_when_empty(tmp_path: Path) -> None:
+    """Passing no log_tail leaves the key absent from the JSON payload."""
+    _make_project(tmp_path)
+    wiki_background.write_last_refresh(
+        tmp_path, exit_code=0, modules_updated=2, elapsed_seconds=0.5
+    )
+    raw = json.loads((tmp_path / ".context" / "wiki" / ".refresh.last").read_text(encoding="utf-8"))
+    assert "log_tail" not in raw
+    rec = wiki_background.read_last_refresh(tmp_path)
+    assert rec is not None
+    assert rec.log_tail is None
+
+
+def test_last_refresh_ignores_non_list_log_tail(tmp_path: Path) -> None:
+    """Forward-compat: a malformed log_tail type drops to None, doesn't crash."""
+    _make_project(tmp_path)
+    (tmp_path / ".context" / "wiki" / ".refresh.last").write_text(
+        json.dumps(
+            {
+                "completed_at": 1.0,
+                "exit_code": 1,
+                "modules_updated": 0,
+                "elapsed_seconds": 0.1,
+                "log_tail": "not a list",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rec = wiki_background.read_last_refresh(tmp_path)
+    assert rec is not None
+    assert rec.log_tail is None

--- a/tests/unit/copilot/test_wiki_bg_runner.py
+++ b/tests/unit/copilot/test_wiki_bg_runner.py
@@ -106,3 +106,96 @@ def test_runner_writes_last_refresh_on_crash(
     assert record is not None
     assert record.exit_code == 1
     assert record.modules_updated == 0
+
+
+# ---- log_tail capture on crash (v0.8.5) -----------------------------------
+
+
+def test_runner_captures_log_tail_from_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Crash path: ``.refresh.log`` content since run-start is captured.
+
+    Since tests don't redirect stdout to ``.refresh.log`` like the real
+    parent does, we seed the file ourselves between ``_initial_log_offset``
+    and the finally-block capture — that's what a real parent
+    would have written from the crashed runner's stderr.
+    """
+    _make_project(tmp_path)
+    log_path = tmp_path / ".context" / "wiki" / ".refresh.log"
+    # Pre-run content — the runner's offset capture must ignore this.
+    log_path.write_text("old-run boilerplate\n", encoding="utf-8")
+
+    def fake_update(
+        _root: Path,
+        *,
+        all_modules: bool,
+        on_progress: Callable[..., None],
+    ) -> tuple[int, list[str]]:
+        # Simulate crash output arriving in the log file mid-run.
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write("2026-04-24 [bg-wiki pid=1] Traceback (most recent call last):\n")
+            fh.write('  File "x.py", line 10, in _run\n    raise RuntimeError("boom")\n')
+            fh.write("RuntimeError: boom\n")
+        raise RuntimeError("boom")
+
+    _install_fake_orchestrator(monkeypatch, fake=fake_update)
+    exit_code = _wiki_bg_runner.main([str(tmp_path)])
+    assert exit_code == 1
+
+    record = wiki_background.read_last_refresh(tmp_path)
+    assert record is not None
+    assert record.log_tail is not None
+    tail = list(record.log_tail)
+    # Pre-run line filtered out (offset).
+    assert "old-run boilerplate" not in tail
+    # Traceback surfaced.
+    assert any("RuntimeError: boom" in line for line in tail)
+
+
+def test_runner_log_tail_is_none_on_clean_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Clean runs: no diagnostic tail persisted (keeps the record small)."""
+    _make_project(tmp_path)
+    # Even if .refresh.log has content, clean exit should not capture it.
+    (tmp_path / ".context" / "wiki" / ".refresh.log").write_text("some line\n", encoding="utf-8")
+
+    def fake_update(
+        _root: Path,
+        *,
+        all_modules: bool,
+        on_progress: Callable[..., None],
+    ) -> tuple[int, list[str]]:
+        on_progress(done=1, total=1, current="x")
+        return (1, [])
+
+    _install_fake_orchestrator(monkeypatch, fake=fake_update)
+    exit_code = _wiki_bg_runner.main([str(tmp_path)])
+    assert exit_code == 0
+    record = wiki_background.read_last_refresh(tmp_path)
+    assert record is not None
+    assert record.log_tail is None
+
+
+def test_runner_log_tail_is_none_on_sigterm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SIGTERM cancellations don't attach a tail — the 'cancelled' label suffices."""
+    _make_project(tmp_path)
+    (tmp_path / ".context" / "wiki" / ".refresh.log").write_text("irrelevant\n", encoding="utf-8")
+
+    def fake_update(
+        _root: Path,
+        *,
+        all_modules: bool,
+        on_progress: Callable[..., None],
+    ) -> tuple[int, list[str]]:
+        raise SystemExit(143)
+
+    _install_fake_orchestrator(monkeypatch, fake=fake_update)
+    exit_code = _wiki_bg_runner.main([str(tmp_path)])
+    assert exit_code == 143
+    record = wiki_background.read_last_refresh(tmp_path)
+    assert record is not None
+    assert record.log_tail is None

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "lv-dcp"
-version = "0.8.4"
+version = "0.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- On a crashed background wiki refresh, the runner now captures the current run's last ~20 lines of `.refresh.log` into `.refresh.last.log_tail`.
- `ctx project check` renders them as an indented `log tail:` block under the `FAILED exit=…` last-run hint — no more `cat .refresh.log` step.
- Suppressed on clean / SIGTERM exits and while a refresh is in progress (live progress supersedes the tail).

## Details

- Runner captures `stat().st_size` at startup (before its first log line) and seeks past it on crash paths only (`exit_code not in (0, 143)`). `.refresh.log` is append-only across runs, so the offset is what keeps previous crashes from leaking into the current record.
- `LastRefreshRecord.log_tail: tuple[str, ...] | None` — frozen dataclass; capped at 20 lines at write time; missing / malformed payload values read as `None`.
- `CopilotCheckReport.wiki_last_refresh_log_tail: list[str] | None` — same nullability as v0.8.4's four `wiki_last_refresh_*` fields.
- CLI: `_render_check` appends `    log tail:` + 6-space-indented lines under `bg_refresh` only when `wiki_last_refresh_exit_code not in (None, 0, 143)` and no refresh is in progress.
- Closes the "No error-tail surface" gap called out in v0.8.4's release notes.

## Test plan

- [x] `uv run python -m pytest --ignore=tests/perf -q` — 1130 passed, 1 skipped (+12 vs v0.8.4).
- [x] `make lint` — ruff + format clean.
- [x] `make typecheck` — mypy strict, 373 source files, no issues.
- [x] New coverage: `test_wiki_background.py` (schema round-trip, 20-line cap, empty omission, malformed tolerance), `test_wiki_bg_runner.py` (crash captures, clean → None, SIGTERM → None), `test_check_project.py` (report surfaces tail on crash, None on clean), `test_project_cmd.py` (CLI renders indented block on FAILED, suppresses on clean + SIGTERM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)