### PR TITLE
release(v0.8.6): MCP lvdcp_status surfaces bg refresh state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.5-log-tail.md)
-[![Version 0.8.5](https://img.shields.io/badge/version-0.8.5-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md)
+[![Version 0.8.6](https://img.shields.io/badge/version-0.8.6-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.6 (2026-04-24)** — MCP `lvdcp_status` surfaces bg refresh state. `ProjectStatus` gains `wiki_refresh: WikiBackgroundRefresh | None` — a nested block that mirrors `CopilotCheckReport.wiki_refresh_*` / `wiki_last_refresh_*` (live progress + last-run outcome + crash tail). Agents calling `lvdcp_status(path=…)` now see the same bg-refresh state `ctx project check` shows on the CLI, so they can decide "refresh or pack" without shelling out. Lazy import of `libs.copilot` keeps non-wiki consumers from paying the cost. No new deps.
+
 **v0.8.5 (2026-04-24)** — Error log tail. On a non-clean, non-SIGTERM exit the runner seeks past its startup offset in `.refresh.log` and persists the current run's last ~20 lines as `log_tail` in `.refresh.last`. `ctx project check` renders them as an indented `log tail:` block under the `FAILED exit=…` last-run hint, so diagnosing a crashed refresh no longer requires a second `cat .refresh.log` step. Suppressed on clean / SIGTERM exits and while a refresh is in progress. Closes the *"No error-tail surface"* gap from v0.8.4. No new deps.
 
 **v0.8.4 (2026-04-24)** — `.refresh.last` outcome record. After every background wiki refresh finishes (cleanly, via SIGTERM, or crash), the runner's `finally` block writes `.context/wiki/.refresh.last` with `{completed_at, exit_code, modules_updated, elapsed_seconds}`. `ctx project check` then renders `bg_refresh=false (last: ok 12 modules 47s, 3 min ago)` — or `FAILED exit=1 … — see .refresh.log` for crashes. Closes the *"No transition-to-error surface"* gap from v0.8.3: the watcher now tells you *why* the refresh stopped, not just *that* it stopped. No new deps, no new process.
@@ -76,6 +78,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md](docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md) (v0.8.6 — MCP `lvdcp_status` surfaces bg refresh state)
 - [docs/release/2026-04-24-v0.8.5-log-tail.md](docs/release/2026-04-24-v0.8.5-log-tail.md) (v0.8.5 — Error log tail)
 - [docs/release/2026-04-24-v0.8.4-last-refresh.md](docs/release/2026-04-24-v0.8.4-last-refresh.md) (v0.8.4 — `.refresh.last` outcome record)
 - [docs/release/2026-04-24-v0.8.3-check-watch.md](docs/release/2026-04-24-v0.8.3-check-watch.md) (v0.8.3 — `ctx project check --watch`)
@@ -434,6 +437,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.3** (done) — `ctx project check --watch`: generator-based live-tail that polls the lock and re-prints the snapshot until the refresh settles. `--json` mode streams consecutive reports separated by blank lines. Closes the "no live tail" gap from v0.8.2. No threads, no new deps.
 - **v0.8.4** (done) — `.refresh.last` outcome record: the runner writes `{completed_at, exit_code, modules_updated, elapsed_seconds}` in its `finally` block (clean / SIGTERM / crash all covered), and `ctx project check` renders `bg_refresh=false (last: ok 12 modules 47s, 3 min ago)` or `FAILED exit=1 … — see .refresh.log`. Closes the "no transition-to-error surface" gap from v0.8.3. No new deps, no new process.
 - **v0.8.5** (done) — Error log tail: on a non-clean, non-SIGTERM exit the runner captures the current run's last ~20 lines of `.refresh.log` into `.refresh.last.log_tail`, and `ctx project check` renders them as an indented block under the `FAILED exit=…` last-run hint — so diagnosing a crashed refresh no longer needs a second `cat .refresh.log`. Closes the "no error-tail surface" gap from v0.8.4. No new deps.
+- **v0.8.6** (done) — MCP `lvdcp_status` surfaces bg refresh state. `ProjectStatus.wiki_refresh` (nested) mirrors the `CopilotCheckReport.wiki_refresh_*` / `wiki_last_refresh_*` fields so agents and dashboards see the same bg-refresh snapshot the CLI shows (live progress, last-run outcome, crash tail). Lazy import of `libs.copilot` keeps non-wiki consumers cost-free. No new deps.
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/mcp/tools.py
+++ b/apps/mcp/tools.py
@@ -567,6 +567,11 @@ def lvdcp_status(path: str | None = None) -> StatusResponse:
     - Get detailed per-project data including dependency graph
       (`lvdcp_status(path="/abs/project")`)
     - See Claude Code token usage rolling totals per project or workspace-wide
+    - Inspect background wiki-refresh state before deciding whether to
+      trigger a refresh — the per-project response exposes ``wiki_refresh``
+      with live progress (``in_progress``, ``phase``, ``modules_done/total``)
+      and the last run's outcome (``last_exit_code``, ``last_log_tail`` on
+      crash). Mirrors what ``ctx project check`` prints on the CLI.
 
     DO NOT CALL FOR:
     - Replacing `lvdcp_pack` (use pack for code context, status for meta-level state)

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -22,7 +22,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.5</span>
+        <span>LV_DCP Dashboard &bull; v0.8.6</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.5",
+    "version": "0.8.6",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md
+++ b/docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md
@@ -1,0 +1,154 @@
+# LV_DCP v0.8.6 — MCP `lvdcp_status` surfaces bg refresh state
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** parity between the CLI `ctx project check` observability
+(shipped in v0.8.1–v0.8.5) and the MCP `lvdcp_status` tool — so a Claude
+Code agent calling the MCP sees the same bg-refresh state a human
+operator does.
+
+## Why
+
+After v0.8.1–v0.8.5 the CLI knows everything about a background wiki
+refresh:
+
+- *is one running?* — `bg_refresh=true (generating 3/12 "libs/foo" pid=1234)`
+- *what happened last time?* — `last: FAILED exit=1 after 4 modules 12s, 3 min ago`
+- *why did it fail?* — indented `log tail:` block under the last-run hint
+
+But agents calling `lvdcp_status(path=…)` see a `ProjectStatus` with
+`card` / `sparklines` / `graph` / `hotspots` / `scan_coverage` and **no
+bg-refresh fields at all**. An agent deciding "should I trigger
+`lvdcp_scan` and then pack, or is the wiki already refreshing?" has to
+shell out to `ctx project check` or re-parse `.context/wiki/.refresh.lock`
+itself.
+
+v0.8.6 adds one new nested field — `ProjectStatus.wiki_refresh: WikiBackgroundRefresh | None`
+— that mirrors the `CopilotCheckReport` surface. The aggregator calls
+`libs.copilot.wiki_background.read_status()` (a lazy import so
+non-wiki consumers don't pay the cost) and maps its 10-field snapshot
+onto a flat pydantic model. No new I/O paths, no new lock format — just
+a read-through surface.
+
+## Shipped
+
+### New DTO: `libs/status/models.py::WikiBackgroundRefresh`
+
+```python
+class WikiBackgroundRefresh(BaseModel):
+    # Live progress (populated when a refresh is running)
+    in_progress: bool = False
+    phase: str | None = None            # starting | loading | generating | finalizing
+    modules_total: int | None = None
+    modules_done: int = 0
+    current_module: str | None = None
+    pid: int | None = None
+
+    # Last-run outcome (populated from .refresh.last)
+    last_completed_at: float | None = None
+    last_exit_code: int | None = None           # 0 / 143 / other
+    last_modules_updated: int | None = None
+    last_elapsed_seconds: float | None = None
+    last_log_tail: list[str] | None = None      # only on crash
+```
+
+Field semantics exactly match `CopilotCheckReport.wiki_refresh_*` /
+`wiki_last_refresh_*`. The two surfaces can now be compared
+side-by-side without re-deriving anything.
+
+### Aggregator: `libs/status/aggregator.py::_build_wiki_refresh`
+
+Thin mapping helper. Lazy-imports `libs.copilot.wiki_background.read_status`
+so projects that never touch the wiki pipeline don't pay the import
+cost. Any read error (missing lock, torn JSON, `libs.copilot` import
+failure) returns `None` — consistent with how `_build_scan_coverage`
+handles `ProjectNotIndexedError`.
+
+```python
+hotspots = _build_hotspots(root)
+coverage = _build_scan_coverage(root)
+wiki_refresh = _build_wiki_refresh(root)     # ← new in v0.8.6
+```
+
+### `ProjectStatus` extension
+
+```python
+wiki_refresh: WikiBackgroundRefresh | None = None
+```
+
+Default `None` keeps existing JSON consumers working — callers that
+don't care about bg refresh state can ignore the field.
+
+### `lvdcp_status` docstring
+
+Added a `CALL THIS TO:` bullet:
+
+> Inspect background wiki-refresh state before deciding whether to
+> trigger a refresh — the per-project response exposes `wiki_refresh`
+> with live progress (`in_progress`, `phase`, `modules_done/total`)
+> and the last run's outcome (`last_exit_code`, `last_log_tail` on
+> crash). Mirrors what `ctx project check` prints on the CLI.
+
+## Tests
+
+- **+4** in `tests/unit/status/test_aggregator.py`:
+  - `wiki_refresh_idle_with_no_history` — fresh project, no refresh
+    ever run: `in_progress=False`, every other field default / None.
+  - `wiki_refresh_surfaces_last_crash` — `write_last_refresh` with
+    `exit_code=1` + a 3-line tail round-trips through the aggregator.
+  - `wiki_refresh_shows_live_progress` — seed `.refresh.lock` with
+    progress payload, monkeypatch `_pid_alive=True`, assert
+    `in_progress=True` + `phase=generating` + `modules_done=2/5` +
+    `current_module="libs/foo"` + `pid=42424`.
+  - `wiki_refresh_clean_last_run_has_no_log_tail` — clean exit
+    `write_last_refresh` leaves `last_log_tail=None` even though
+    `last_exit_code=0` is populated.
+- **Total suite: 1134 passing (+4 vs v0.8.5).** Ruff + format + mypy
+  strict clean across 373 source files.
+
+## Design notes
+
+- **Nested model, not flat fields.** `CopilotCheckReport` chose flat
+  fields (`wiki_refresh_phase`, `wiki_last_refresh_log_tail`, …) to
+  keep JSON keys one level deep for CLI consumers. `ProjectStatus`
+  already nests `card` / `graph` / `hotspots`, so a nested
+  `wiki_refresh` fits the surrounding style better. MCP clients see
+  `status.project.wiki_refresh.last_log_tail`, which is a clearer path
+  than a flat `wiki_last_refresh_log_tail`.
+- **Lazy import of `libs.copilot`.** The copilot module pulls in the
+  scanning stack transitively; eagerly importing it at status-layer
+  import time would slow down every `lvdcp_status()` call that doesn't
+  need wiki data (e.g. `lvdcp_status()` with no path, which builds
+  `WorkspaceStatus` only). Deferring to the helper keeps the cost
+  opt-in.
+- **Best-effort.** A missing or torn lock file, an ENOENT on
+  `.refresh.last`, or a future `libs.copilot` refactor that breaks the
+  import — all resolve to `wiki_refresh=None`. The status payload never
+  fails because of a bg-refresh read.
+- **No CLI change.** `ctx project check` still consumes
+  `CopilotCheckReport`, not `ProjectStatus`. This release is strictly
+  an MCP-facing surface; the human-facing path continues through the
+  same primitives it used in v0.8.1–v0.8.5.
+
+## Migration / compat
+
+- `ProjectStatus.wiki_refresh` defaults to `None`; existing JSON / HTTP
+  consumers of the FastAPI dashboard and of `lvdcp_status` keep
+  working unchanged.
+- No DB migration, no config knob, no new deps.
+- Same schema-evolution rules as v0.8.4/v0.8.5: old clients that don't
+  know the field simply drop it.
+
+## Known gaps (carry-forward)
+
+- **Dashboard UI doesn't render `wiki_refresh`.** The FastAPI
+  `/status` pages are unchanged — the data is now available to them
+  but there's no corresponding widget. A tiny HTMX panel on the
+  per-project page (running / idle / FAILED with tail) is a cheap
+  follow-up once the need shows up.
+- **No webhook on transition.** A watcher using `lvdcp_status` has to
+  poll. The existing `ctx project check --watch` generator primitive
+  could be ported to the MCP transport as a streaming tool, but that's
+  a bigger design call (MCP streaming is optional on most clients).
+- **No retry / auto-heal.** Same as v0.8.5: a crashed refresh is now
+  fully visible to MCP agents, but still not auto-retried.

--- a/libs/status/aggregator.py
+++ b/libs/status/aggregator.py
@@ -36,6 +36,7 @@ from libs.status.models import (
     ProjectStatus,
     SparklineSeries,
     TokenTotals,
+    WikiBackgroundRefresh,
     WorkspaceStatus,
 )
 
@@ -212,6 +213,7 @@ def build_project_status(project_root: Path) -> ProjectStatus:
 
     hotspots = _build_hotspots(root)
     coverage = _build_scan_coverage(root)
+    wiki_refresh = _build_wiki_refresh(root)
 
     return ProjectStatus(
         card=card,
@@ -221,6 +223,50 @@ def build_project_status(project_root: Path) -> ProjectStatus:
         graph=graph,
         hotspots=hotspots,
         scan_coverage=coverage,
+        wiki_refresh=wiki_refresh,
+    )
+
+
+def _build_wiki_refresh(root: Path) -> WikiBackgroundRefresh | None:
+    """Assemble the MCP-facing background wiki-refresh snapshot.
+
+    Thin mapping over :func:`libs.copilot.wiki_background.read_status` —
+    flattens the nested ``last_run`` record into ``last_*`` fields so
+    agents calling ``lvdcp_status`` don't need to know the internal
+    dataclass shape. Returns ``None`` on any read error (best-effort: a
+    missing or torn lock file shouldn't break the whole status
+    payload).
+    """
+    try:
+        # Lazy import: ``libs.copilot`` pulls in the scanning stack, and
+        # callers of ``libs.status`` that don't care about wiki refresh
+        # shouldn't pay that import cost.
+        from libs.copilot.wiki_background import read_status as _read_bg_status  # noqa: PLC0415
+    except Exception:
+        return None
+    try:
+        bg = _read_bg_status(root)
+    except Exception:
+        return None
+
+    last_run = bg.last_run
+    log_tail = (
+        list(last_run.log_tail)
+        if (last_run is not None and last_run.log_tail is not None)
+        else None
+    )
+    return WikiBackgroundRefresh(
+        in_progress=bg.in_progress,
+        phase=bg.phase,
+        modules_total=bg.modules_total,
+        modules_done=bg.modules_done,
+        current_module=bg.current_module,
+        pid=bg.pid,
+        last_completed_at=last_run.completed_at if last_run is not None else None,
+        last_exit_code=last_run.exit_code if last_run is not None else None,
+        last_modules_updated=last_run.modules_updated if last_run is not None else None,
+        last_elapsed_seconds=last_run.elapsed_seconds if last_run is not None else None,
+        last_log_tail=log_tail,
     )
 
 

--- a/libs/status/models.py
+++ b/libs/status/models.py
@@ -79,6 +79,80 @@ class HotspotInfo(BaseModel):
     score: float
 
 
+class WikiBackgroundRefresh(BaseModel):
+    """Background wiki refresh observability for MCP consumers.
+
+    Mirrors the ``wiki_refresh_*`` / ``wiki_last_refresh_*`` fields that
+    :class:`libs.copilot.CopilotCheckReport` already surfaces on the CLI
+    side, so an agent calling ``lvdcp_status`` sees the same state a
+    human sees from ``ctx project check``.
+
+    All fields are nullable on purpose: ``in_progress=False`` with every
+    other field ``None`` means "nothing running, never ran"; a running
+    refresh populates the live-progress fields; a finished refresh
+    populates the ``last_*`` fields. The two sets can be populated at
+    the same time — a new refresh that starts right after an old one
+    crashed will have both the live progress *and* the last-run tail.
+    """
+
+    in_progress: bool = Field(
+        default=False,
+        description=(
+            "True when ``.context/wiki/.refresh.lock`` is present and owned "
+            "by a live PID — matches ``CopilotCheckReport.wiki_refresh_in_progress``."
+        ),
+    )
+    phase: str | None = Field(
+        default=None,
+        description=(
+            "Current phase of an in-progress refresh: "
+            "``starting`` | ``loading`` | ``generating`` | ``finalizing``."
+        ),
+    )
+    modules_total: int | None = Field(
+        default=None,
+        description="Total modules the runner plans to update; None until enumerated.",
+    )
+    modules_done: int = Field(
+        default=0, description="Modules already processed in the current refresh."
+    )
+    current_module: str | None = Field(
+        default=None, description="Module currently being (re)generated, if any."
+    )
+    pid: int | None = Field(
+        default=None, description="PID of the running runner, or None when idle."
+    )
+    last_completed_at: float | None = Field(
+        default=None,
+        description="Unix ts when the most recent refresh finished, regardless of outcome.",
+    )
+    last_exit_code: int | None = Field(
+        default=None,
+        description=(
+            "Exit code of the most recent refresh. 0 = clean; 143 = SIGTERM; "
+            "anything else = crash. None when no refresh has ever run."
+        ),
+    )
+    last_modules_updated: int | None = Field(
+        default=None,
+        description=(
+            "Modules touched by the most recent refresh; for crashes this reflects "
+            "the last progress checkpoint, not the intended total."
+        ),
+    )
+    last_elapsed_seconds: float | None = Field(
+        default=None, description="Wall-clock duration of the most recent refresh."
+    )
+    last_log_tail: list[str] | None = Field(
+        default=None,
+        description=(
+            "Last ~20 lines of ``.refresh.log`` captured at runner exit, populated "
+            "only when the most recent refresh crashed (non-zero, non-SIGTERM exit). "
+            "None for clean / cancelled runs and when no refresh has ever happened."
+        ),
+    )
+
+
 class ProjectStatus(BaseModel):
     card: HealthCard
     claude_usage_7d: TokenTotals
@@ -87,6 +161,15 @@ class ProjectStatus(BaseModel):
     graph: GraphDump | None = None
     hotspots: list[HotspotInfo] = Field(default_factory=list)
     scan_coverage: dict[str, object] | None = None
+    wiki_refresh: WikiBackgroundRefresh | None = Field(
+        default=None,
+        description=(
+            "Background wiki-refresh observability block. None on projects that "
+            "predate v0.8.1 or when the status layer couldn't read the lock / "
+            "``.refresh.last`` file; a concrete value means the aggregator checked "
+            "and found either an idle project or live / historical refresh state."
+        ),
+    )
 
 
 class WorkspaceStatus(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.5"
+version = "0.8.6"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/status/test_aggregator.py
+++ b/tests/unit/status/test_aggregator.py
@@ -69,3 +69,135 @@ def test_build_project_status_has_four_sparklines(tmp_path: Path, isolated_env: 
     status = build_project_status(project.resolve())
     metrics = {s.metric for s in status.sparklines}
     assert {"queries", "scans", "latency_p95_ms", "coverage"} == metrics
+
+
+# ---- wiki_refresh surface (v0.8.6) ----------------------------------------
+
+
+def _seed_scan(project: Path) -> None:
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "main.py").write_text("def f() -> None: return None\n", encoding="utf-8")
+    scan_project(project, mode="full")
+
+
+def test_build_project_status_wiki_refresh_idle_with_no_history(
+    tmp_path: Path, isolated_env: Path
+) -> None:
+    """Fresh project, no refresh ever run → all fields are default/empty."""
+    project = tmp_path / "proj"
+    _seed_scan(project)
+    add_project(isolated_env, project)
+
+    status = build_project_status(project.resolve())
+    assert status.wiki_refresh is not None
+    wr = status.wiki_refresh
+    assert wr.in_progress is False
+    assert wr.phase is None
+    assert wr.modules_total is None
+    assert wr.modules_done == 0
+    assert wr.pid is None
+    assert wr.last_completed_at is None
+    assert wr.last_exit_code is None
+    assert wr.last_log_tail is None
+
+
+def test_build_project_status_wiki_refresh_surfaces_last_crash(
+    tmp_path: Path, isolated_env: Path
+) -> None:
+    """A crashed refresh populates ``last_*`` including the log tail."""
+    from libs.copilot import write_last_refresh
+
+    project = tmp_path / "proj"
+    _seed_scan(project)
+    add_project(isolated_env, project)
+    (project / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+
+    tail = [
+        "Traceback (most recent call last):",
+        '  File "x.py", line 10, in _run',
+        "RuntimeError: boom",
+    ]
+    write_last_refresh(
+        project,
+        exit_code=1,
+        modules_updated=2,
+        elapsed_seconds=0.5,
+        completed_at=1_700_000_000.0,
+        log_tail=tail,
+    )
+
+    status = build_project_status(project.resolve())
+    assert status.wiki_refresh is not None
+    wr = status.wiki_refresh
+    assert wr.in_progress is False
+    assert wr.last_exit_code == 1
+    assert wr.last_modules_updated == 2
+    assert wr.last_elapsed_seconds == pytest.approx(0.5)
+    assert wr.last_completed_at == pytest.approx(1_700_000_000.0)
+    assert wr.last_log_tail == tail
+
+
+def test_build_project_status_wiki_refresh_shows_live_progress(
+    tmp_path: Path, isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live lock with progress payload populates the ``in_progress`` block."""
+    import json as _json
+    import time as _time
+
+    project = tmp_path / "proj"
+    _seed_scan(project)
+    add_project(isolated_env, project)
+
+    wiki_dir = project / ".context" / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    (wiki_dir / ".refresh.lock").write_text(
+        _json.dumps(
+            {
+                "pid": 42424,
+                "started_at": _time.time(),
+                "all_modules": False,
+                "phase": "generating",
+                "modules_total": 5,
+                "modules_done": 2,
+                "current_module": "libs/foo",
+            }
+        ),
+        encoding="utf-8",
+    )
+    from libs.copilot import wiki_background
+
+    monkeypatch.setattr(wiki_background, "_pid_alive", lambda _pid: True)
+
+    status = build_project_status(project.resolve())
+    assert status.wiki_refresh is not None
+    wr = status.wiki_refresh
+    assert wr.in_progress is True
+    assert wr.phase == "generating"
+    assert wr.modules_total == 5
+    assert wr.modules_done == 2
+    assert wr.current_module == "libs/foo"
+    assert wr.pid == 42424
+
+
+def test_build_project_status_wiki_refresh_clean_last_run_has_no_log_tail(
+    tmp_path: Path, isolated_env: Path
+) -> None:
+    """Clean runs intentionally leave ``last_log_tail`` empty."""
+    from libs.copilot import write_last_refresh
+
+    project = tmp_path / "proj"
+    _seed_scan(project)
+    add_project(isolated_env, project)
+    (project / ".context" / "wiki").mkdir(parents=True, exist_ok=True)
+    write_last_refresh(
+        project,
+        exit_code=0,
+        modules_updated=3,
+        elapsed_seconds=2.0,
+        completed_at=1_700_000_000.0,
+    )
+
+    status = build_project_status(project.resolve())
+    assert status.wiki_refresh is not None
+    assert status.wiki_refresh.last_exit_code == 0
+    assert status.wiki_refresh.last_log_tail is None

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "lv-dcp"
-version = "0.8.5"
+version = "0.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- `ProjectStatus.wiki_refresh: WikiBackgroundRefresh | None` — new nested block that mirrors `CopilotCheckReport.wiki_refresh_*` / `wiki_last_refresh_*` from v0.8.4–v0.8.5.
- `lvdcp_status(path=…)` MCP clients now see the same bg-refresh snapshot the CLI shows: live progress (`in_progress`, `phase`, `modules_done`/`modules_total`, `current_module`, `pid`) + last-run outcome (`last_completed_at`, `last_exit_code`, `last_modules_updated`, `last_elapsed_seconds`) + `last_log_tail` on crash.
- Aggregator lazy-imports `libs.copilot.wiki_background.read_status` so non-wiki consumers of `libs.status` don't pay the scanning-stack import cost.

## Details

- Closes the MCP-side of the gap the CLI already closed via v0.8.1→v0.8.5. An agent deciding "should I `lvdcp_scan` / trigger a refresh, or is one already running?" no longer has to shell out to `ctx project check` or re-parse `.refresh.lock`.
- `_build_wiki_refresh(root)` returns `None` on any read error (missing lock, torn JSON, copilot import failure) — consistent with `_build_scan_coverage`'s best-effort semantics. The status payload never fails because of a bg-refresh read.
- Nested model rather than flat fields on `ProjectStatus` — MCP clients address the data as `status.project.wiki_refresh.last_log_tail`, matching the surrounding `card` / `graph` / `hotspots` shape.
- Docstring on `apps/mcp/tools.py::lvdcp_status` gets a new `CALL THIS TO:` bullet pointing agents at the new field.

## Test plan

- [x] `uv run python -m pytest --ignore=tests/perf -q` — 1134 passed, 1 skipped (+4 vs v0.8.5).
- [x] `make lint` — ruff + format clean.
- [x] `make typecheck` — mypy strict, 373 source files, no issues.
- [x] New coverage in `tests/unit/status/test_aggregator.py`: idle project (no history), crashed last-run surfaces full tail, live progress with PID + phase + module counts, clean last-run suppresses tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)