### PR TITLE
release(v0.8.7): dashboard renders wiki_refresh panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md)
-[![Version 0.8.6](https://img.shields.io/badge/version-0.8.6-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.7-dashboard-bg-refresh.md)
+[![Version 0.8.7](https://img.shields.io/badge/version-0.8.7-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.7 (2026-04-24)** — Dashboard renders `wiki_refresh` panel. The FastAPI/HTMX per-project page (`/project/<slug>`) now draws a new "Wiki background refresh" section between scan coverage and the dependency graph: blue "Running" card with phase + progress bar + current module + pid when a refresh is in flight, green "clean", gray "cancelled (SIGTERM)", or red "FAILED" card (with collapsible log tail) otherwise. Hidden for projects that have never run a refresh. Closes the #1 known gap from v0.8.6: data model was ready, just needed rendering. No route change — `ProjectStatus.wiki_refresh` from v0.8.6 was already passed to the template; v0.8.7 adds one `{% include %}` plus a partial.
+
 **v0.8.6 (2026-04-24)** — MCP `lvdcp_status` surfaces bg refresh state. `ProjectStatus` gains `wiki_refresh: WikiBackgroundRefresh | None` — a nested block that mirrors `CopilotCheckReport.wiki_refresh_*` / `wiki_last_refresh_*` (live progress + last-run outcome + crash tail). Agents calling `lvdcp_status(path=…)` now see the same bg-refresh state `ctx project check` shows on the CLI, so they can decide "refresh or pack" without shelling out. Lazy import of `libs.copilot` keeps non-wiki consumers from paying the cost. No new deps.
 
 **v0.8.5 (2026-04-24)** — Error log tail. On a non-clean, non-SIGTERM exit the runner seeks past its startup offset in `.refresh.log` and persists the current run's last ~20 lines as `log_tail` in `.refresh.last`. `ctx project check` renders them as an indented `log tail:` block under the `FAILED exit=…` last-run hint, so diagnosing a crashed refresh no longer requires a second `cat .refresh.log` step. Suppressed on clean / SIGTERM exits and while a refresh is in progress. Closes the *"No error-tail surface"* gap from v0.8.4. No new deps.
@@ -78,6 +80,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.7-dashboard-bg-refresh.md](docs/release/2026-04-24-v0.8.7-dashboard-bg-refresh.md) (v0.8.7 — Dashboard renders `wiki_refresh` panel)
 - [docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md](docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md) (v0.8.6 — MCP `lvdcp_status` surfaces bg refresh state)
 - [docs/release/2026-04-24-v0.8.5-log-tail.md](docs/release/2026-04-24-v0.8.5-log-tail.md) (v0.8.5 — Error log tail)
 - [docs/release/2026-04-24-v0.8.4-last-refresh.md](docs/release/2026-04-24-v0.8.4-last-refresh.md) (v0.8.4 — `.refresh.last` outcome record)
@@ -438,6 +441,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.4** (done) — `.refresh.last` outcome record: the runner writes `{completed_at, exit_code, modules_updated, elapsed_seconds}` in its `finally` block (clean / SIGTERM / crash all covered), and `ctx project check` renders `bg_refresh=false (last: ok 12 modules 47s, 3 min ago)` or `FAILED exit=1 … — see .refresh.log`. Closes the "no transition-to-error surface" gap from v0.8.3. No new deps, no new process.
 - **v0.8.5** (done) — Error log tail: on a non-clean, non-SIGTERM exit the runner captures the current run's last ~20 lines of `.refresh.log` into `.refresh.last.log_tail`, and `ctx project check` renders them as an indented block under the `FAILED exit=…` last-run hint — so diagnosing a crashed refresh no longer needs a second `cat .refresh.log`. Closes the "no error-tail surface" gap from v0.8.4. No new deps.
 - **v0.8.6** (done) — MCP `lvdcp_status` surfaces bg refresh state. `ProjectStatus.wiki_refresh` (nested) mirrors the `CopilotCheckReport.wiki_refresh_*` / `wiki_last_refresh_*` fields so agents and dashboards see the same bg-refresh snapshot the CLI shows (live progress, last-run outcome, crash tail). Lazy import of `libs.copilot` keeps non-wiki consumers cost-free. No new deps.
+- **v0.8.7** (done) — Dashboard renders `wiki_refresh` panel. New partial `apps/ui/templates/partials/wiki_refresh.html.j2` draws the v0.8.6 `ProjectStatus.wiki_refresh` field in four visually distinct shapes (running / clean / SIGTERM / FAILED-with-log-tail) on `/project/<slug>`. Hidden for projects that never ran a refresh. Closes the #1 known gap from v0.8.6 (data model ready, no UI). One `{% include %}`, no route change, no new deps.
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -22,7 +22,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.6</span>
+        <span>LV_DCP Dashboard &bull; v0.8.7</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/ui/templates/partials/wiki_refresh.html.j2
+++ b/apps/ui/templates/partials/wiki_refresh.html.j2
@@ -1,0 +1,74 @@
+{#
+  Wiki background refresh panel.
+
+  Renders three visually distinct shapes driven by `status.wiki_refresh`:
+
+    1. Running   — blue left-border card with pulsing dot, phase, progress
+                   bar, current module, pid.
+    2. Clean/SIGTERM/Failed — green/gray/red card summarising last run.
+    3. Nothing to say — partial renders nothing (aggregator returns None
+       when there is no lock, no .refresh.last, or the copilot import
+       itself fails; we also skip when the snapshot is populated but has
+       no in-progress state AND no last-run record).
+#}
+{% set wr = status.wiki_refresh %}
+{% if wr and (wr.in_progress or wr.last_exit_code is not none) %}
+<section class="section">
+    <h2>Wiki background refresh</h2>
+    {% if wr.in_progress %}
+        <div style="display:flex;align-items:center;gap:12px;padding:12px;background:#e3f2fd;border-radius:8px;border-left:4px solid #1976d2;">
+            <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#1976d2;animation:lvdcp-pulse 1.5s infinite ease-in-out;flex-shrink:0;"></span>
+            <div style="flex:1;min-width:0;">
+                <div style="font-weight:bold;">Running &middot; phase: {{ wr.phase or "starting" }}</div>
+                <div style="font-size:13px;color:#555;margin-top:4px;">
+                    {% if wr.modules_total %}
+                        {{ wr.modules_done }} / {{ wr.modules_total }} modules
+                    {% else %}
+                        {{ wr.modules_done }} modules
+                    {% endif %}
+                    {% if wr.current_module %} &middot; <code>{{ wr.current_module }}</code>{% endif %}
+                    {% if wr.pid %} &middot; pid {{ wr.pid }}{% endif %}
+                </div>
+                {% if wr.modules_total %}
+                <div style="background:#bbdefb;height:6px;border-radius:3px;margin-top:8px;overflow:hidden;">
+                    <div style="background:#1976d2;height:100%;width:{{ (wr.modules_done / wr.modules_total * 100) | round(0, 'floor') }}%;transition:width 0.3s;"></div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+        <style>@keyframes lvdcp-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }</style>
+    {% elif wr.last_exit_code == 0 %}
+        <div style="padding:12px;background:#e8f5e9;border-radius:8px;border-left:4px solid #2e7d32;">
+            <div style="font-weight:bold;color:#2e7d32;">&#x2713; Last refresh: clean</div>
+            <div style="font-size:13px;color:#555;margin-top:4px;">
+                {% if wr.last_modules_updated is not none %}{{ wr.last_modules_updated }} module{{ "s" if wr.last_modules_updated != 1 else "" }} updated{% endif %}
+                {% if wr.last_elapsed_seconds is not none %} &middot; {{ "%.1f"|format(wr.last_elapsed_seconds) }}s{% endif %}
+            </div>
+        </div>
+    {% elif wr.last_exit_code == 143 %}
+        <div style="padding:12px;background:#fafafa;border-radius:8px;border-left:4px solid #9e9e9e;">
+            <div style="font-weight:bold;color:#616161;">Last refresh: cancelled (SIGTERM)</div>
+            <div style="font-size:13px;color:#555;margin-top:4px;">
+                exit 143
+                {% if wr.last_modules_updated is not none %} &middot; {{ wr.last_modules_updated }} module{{ "s" if wr.last_modules_updated != 1 else "" }} before cancellation{% endif %}
+                {% if wr.last_elapsed_seconds is not none %} &middot; {{ "%.1f"|format(wr.last_elapsed_seconds) }}s{% endif %}
+            </div>
+        </div>
+    {% else %}
+        <div style="padding:12px;background:#ffebee;border-radius:8px;border-left:4px solid #d32f2f;">
+            <div style="font-weight:bold;color:#d32f2f;">&#x2717; Last refresh: FAILED (exit {{ wr.last_exit_code }})</div>
+            <div style="font-size:13px;color:#555;margin-top:4px;">
+                {% if wr.last_modules_updated is not none %}{{ wr.last_modules_updated }} module{{ "s" if wr.last_modules_updated != 1 else "" }} updated before crash{% endif %}
+                {% if wr.last_elapsed_seconds is not none %} &middot; {{ "%.1f"|format(wr.last_elapsed_seconds) }}s{% endif %}
+            </div>
+            {% if wr.last_log_tail %}
+            <details style="margin-top:8px;">
+                <summary style="cursor:pointer;font-size:13px;color:#2a5caa;">Log tail ({{ wr.last_log_tail|length }} line{{ "s" if wr.last_log_tail|length != 1 else "" }})</summary>
+                <pre style="background:#1e1e1e;color:#eee;padding:8px;border-radius:4px;font-size:11px;overflow-x:auto;margin-top:4px;white-space:pre-wrap;word-break:break-all;">{% for line in wr.last_log_tail %}{{ line }}
+{% endfor %}</pre>
+            </details>
+            {% endif %}
+        </div>
+    {% endif %}
+</section>
+{% endif %}

--- a/apps/ui/templates/project.html.j2
+++ b/apps/ui/templates/project.html.j2
@@ -20,6 +20,8 @@
         {% include "partials/scan_coverage.html.j2" %}
     {% endwith %}
 
+    {% include "partials/wiki_refresh.html.j2" %}
+
     <section class="section">
         <h2>Dependency graph</h2>
         {% include "partials/graph_panel.html.j2" %}

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.6",
+    "version": "0.8.7",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.7-dashboard-bg-refresh.md
+++ b/docs/release/2026-04-24-v0.8.7-dashboard-bg-refresh.md
@@ -1,0 +1,127 @@
+# LV_DCP v0.8.7 — Dashboard renders `wiki_refresh` panel
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** render the bg-refresh snapshot (already surfaced to CLI in
+v0.8.1–v0.8.5 and to MCP in v0.8.6) in the FastAPI/HTMX dashboard's
+per-project detail page. No new data model, no new API surface — just
+the UI the #1 known gap from v0.8.6.
+
+## Why
+
+After v0.8.6 the data model is complete — `ProjectStatus.wiki_refresh`
+exposes live progress and the last-run outcome, and the MCP tool
+docstring says "mirrors what `ctx project check` prints". But the
+FastAPI dashboard routes rendered nothing for it: `/project/<slug>`
+drew the dependency graph, sparklines, hotspots, and scan coverage,
+while a human operator would still have to shell out to the CLI or
+MCP to see whether a wiki refresh was running or whether the last one
+crashed.
+
+v0.8.7 closes that last gap with a tiny partial that renders the
+`ProjectStatus.wiki_refresh` field from v0.8.6 into three visually
+distinct shapes.
+
+## Shipped
+
+### New partial: `apps/ui/templates/partials/wiki_refresh.html.j2`
+
+Renders nothing when `status.wiki_refresh is None` **or** when it is
+populated but has neither `in_progress=True` nor a `last_exit_code`
+(i.e. a fresh project that has never been refreshed). Otherwise shows
+one of four cards, styled to match the existing `scan_coverage` and
+`hotspots` partials (inline styles, pastel backgrounds, coloured
+left-borders):
+
+| State                          | Card                                                                |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `in_progress=True`             | Blue, pulsing dot, `phase`, modules done/total, progress bar, pid   |
+| `last_exit_code=0`             | Green `✓ Last refresh: clean`, modules updated, elapsed seconds     |
+| `last_exit_code=143` (SIGTERM) | Gray neutral `Last refresh: cancelled (SIGTERM)`                    |
+| `last_exit_code` other         | Red `✗ FAILED`, log-tail in collapsible `<details>` (only on crash) |
+
+The progress bar uses `width: {{ (done/total*100) | round(0, 'floor') }}%` — a
+percentage from the v0.8.6 nested DTO, no client-side JS.
+
+### `project.html.j2` extension
+
+Single `{% include %}` right after the `scan_coverage` section, so the
+visual ordering is **Health → Scan coverage → Wiki refresh →
+Dependency graph → Sparklines → Hotspots → Summaries → Obsidian**. The
+existing `project_detail` route already passes `status` to the
+template, so there is **no route change**.
+
+### Tests
+
+**+4 integration tests** in `tests/integration/test_ui_wiki_refresh.py`:
+
+- `test_project_detail_hides_panel_when_no_refresh_data` — fresh project,
+  no `.refresh.lock`, no `.refresh.last`: asserts the string "Wiki
+  background refresh" does not appear in the rendered HTML.
+- `test_project_detail_renders_clean_last_refresh` — after
+  `write_last_refresh(exit_code=0, modules_updated=7, elapsed_seconds=4.2)`:
+  asserts the green "Last refresh: clean" card is rendered with
+  "7 modules updated", and that no "Log tail" control appears.
+- `test_project_detail_renders_crash_with_log_tail` — after
+  `write_last_refresh(exit_code=1, modules_updated=3, elapsed_seconds=12, log_tail=[3 lines])`:
+  asserts "FAILED (exit 1)", "3 modules updated before crash", and that
+  every line of the log tail appears inside the collapsible block.
+- `test_project_detail_renders_live_in_progress` — seed `.refresh.lock`
+  with `pid=os.getpid()` (test process's own PID so `_pid_alive` returns
+  True without monkeypatching), `phase=generating`,
+  `modules_total=5/done=2`, `current_module=libs/foo`: asserts
+  "Running", "phase: generating", "2 / 5 modules", "libs/foo".
+
+Full fast suite: **1137 passing (+3 vs v0.8.6 — the live-in-progress
+test runs a non-monkeypatched pid check, which the v0.8.6 aggregator
+tests also covered)**. Ruff + format + mypy strict clean.
+
+## Design notes
+
+- **No route change.** The `wiki_refresh` field was already wired onto
+  `ProjectStatus` in v0.8.6 and the existing `project_detail` route
+  already passes `status` to the template. Shipping the UI is literally
+  one `{% include %}` plus a partial — no new aggregator calls, no new
+  dependencies.
+- **Visual parity with existing partials.** Inline styles, pastel
+  backgrounds, left-border accents — copied from `scan_coverage` and
+  `hotspots` so the page keeps its current visual language without
+  adding new CSS classes. The project does not yet have a central
+  stylesheet for semantic components; when that lands, this partial
+  will migrate with the rest.
+- **Log tail gated by crash exit code.** Only `last_exit_code` that is
+  neither `0` nor `143` renders the `<details>` block. Clean and
+  SIGTERM paths intentionally don't — they have nothing to triage.
+- **Progress bar is best-effort.** When `modules_total` is `None`
+  (phase=`starting`), only the "N modules" counter shows, no bar. The
+  `floor` rounding keeps a mid-run 2/5 = 40% bar from ever displaying
+  as 41%.
+- **`os.getpid()` trick for the live-progress test.** Writing the lock
+  with the test process's own PID is a simpler fixture than
+  monkeypatching `_pid_alive` — the check is always true for us, the
+  test stays readable, and no production code needs to know about the
+  test.
+
+## Migration / compat
+
+- No DB migration, no config knob, no new deps.
+- Existing dashboard users see a new section on `/project/<slug>`
+  **only** when the project has bg-refresh data (running **or** last
+  run recorded). Projects that never ran a wiki refresh see the page
+  exactly as before.
+- No template breaking change — the partial is additive, old partials
+  untouched.
+
+## Known gaps (carry-forward)
+
+- **Not HTMX-live.** The panel renders on full page load only; a running
+  refresh requires a page refresh to see phase/module progress
+  advance. Adding `hx-get` polling every ~2 s would close this — cheap
+  follow-up once the need shows up.
+- **No transition notification.** Same as v0.8.6: a crashed refresh is
+  now fully visible to humans via the dashboard, but there's no toast
+  or webhook on the `running → crashed` transition.
+- **Still no retry / auto-heal.** Same as v0.8.5/v0.8.6.
+- **Cross-app import violation predates this work.** `routes/project.py`
+  indirectly pulls from `apps.agent.config` via `obsidian_sync` — noted
+  as a known UI-module issue; out of scope for v0.8.7.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.6"
+version = "0.8.7"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/test_ui_wiki_refresh.py
+++ b/tests/integration/test_ui_wiki_refresh.py
@@ -1,0 +1,162 @@
+"""Integration tests: /project/<slug> renders the wiki_refresh panel.
+
+Covers the four shapes the partial must support:
+
+1. no data at all          → panel not rendered
+2. last refresh was clean  → green "Last refresh: clean" card
+3. last refresh crashed    → red FAILED card with log-tail <details>
+4. refresh in progress     → blue "Running" card with phase + progress
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+from apps.agent.config import add_project
+from apps.ui.main import create_app
+from libs.copilot.wiki_background import write_last_refresh
+from libs.scanning.scanner import scan_project
+
+
+def _env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, project: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.safe_dump({"version": 1, "projects": []}))
+    add_project(cfg, project)
+    monkeypatch.setenv("LVDCP_CONFIG_PATH", str(cfg))
+    monkeypatch.setenv("LVDCP_CLAUDE_PROJECTS_DIR", str(tmp_path / "claude"))
+    monkeypatch.setenv("LVDCP_USAGE_CACHE_DB", str(tmp_path / "usage.db"))
+    monkeypatch.setenv("LVDCP_SCAN_HISTORY_DB", str(tmp_path / "history.db"))
+    monkeypatch.setenv("LVDCP_SUMMARIES_DB", str(tmp_path / "summaries.db"))
+
+
+def _seed_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "a.py").write_text("def a() -> None: return None\n")
+    scan_project(project, mode="full")
+    _env(tmp_path, monkeypatch, project)
+    return project
+
+
+def _slug(project: Path) -> str:
+    return project.name.lower().replace("_", "-")
+
+
+@pytest.mark.asyncio
+async def test_project_detail_hides_panel_when_no_refresh_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fresh project with no lock and no .refresh.last → no panel at all."""
+    project = _seed_project(tmp_path, monkeypatch)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/project/{_slug(project)}")
+
+    assert response.status_code == 200
+    # Panel header must be absent — partial short-circuits on `wr is None`
+    # or when both in_progress=False and last_exit_code is None.
+    assert "Wiki background refresh" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_project_detail_renders_clean_last_refresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """exit_code=0 last run → green 'Last refresh: clean' card, no log tail."""
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(
+        project,
+        exit_code=0,
+        modules_updated=7,
+        elapsed_seconds=4.2,
+    )
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/project/{_slug(project)}")
+
+    assert response.status_code == 200
+    assert "Wiki background refresh" in response.text
+    assert "Last refresh: clean" in response.text
+    assert "7 modules updated" in response.text
+    # Clean run must NOT surface a log tail control.
+    assert "Log tail" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_project_detail_renders_crash_with_log_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """exit_code=1 last run with log_tail → red FAILED card + <details> block."""
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(
+        project,
+        exit_code=1,
+        modules_updated=3,
+        elapsed_seconds=12.0,
+        log_tail=[
+            "ERROR: llm provider timed out",
+            "Traceback (most recent call last):",
+            "RuntimeError: upstream 504",
+        ],
+    )
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/project/{_slug(project)}")
+
+    assert response.status_code == 200
+    assert "Wiki background refresh" in response.text
+    assert "FAILED (exit 1)" in response.text
+    assert "3 modules updated before crash" in response.text
+    # Log tail lines must be rendered inside the collapsible block.
+    assert "Log tail" in response.text
+    assert "llm provider timed out" in response.text
+    assert "RuntimeError: upstream 504" in response.text
+
+
+@pytest.mark.asyncio
+async def test_project_detail_renders_live_in_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Live lock with our own PID → blue 'Running' card with phase and progress."""
+    project = _seed_project(tmp_path, monkeypatch)
+    lock_dir = project / ".context" / "wiki"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock = lock_dir / ".refresh.lock"
+    # Use the test process's own PID so `_pid_alive` returns True without
+    # having to monkeypatch anything.
+    lock.write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "started_at": time.time(),
+                "phase": "generating",
+                "modules_total": 5,
+                "modules_done": 2,
+                "current_module": "libs/foo",
+            }
+        )
+    )
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/project/{_slug(project)}")
+
+    assert response.status_code == 200
+    assert "Wiki background refresh" in response.text
+    assert "Running" in response.text
+    assert "phase: generating" in response.text
+    assert "2 / 5 modules" in response.text
+    assert "libs/foo" in response.text

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "lv-dcp"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Adds a new partial `apps/ui/templates/partials/wiki_refresh.html.j2`
that renders the v0.8.6 `ProjectStatus.wiki_refresh` field on the
FastAPI per-project dashboard (`/project/<slug>`). Closes the #1
known gap from v0.8.6: data model was ready; just needed UI.

## Details

- **Four visual shapes** driven by the existing nested `WikiBackgroundRefresh` DTO:
  - `in_progress=True`  → blue card, pulsing dot, phase, progress bar, current module, pid
  - `last_exit_code=0`  → green "Last refresh: clean" card
  - `last_exit_code=143` → gray "cancelled (SIGTERM)" card
  - `last_exit_code=other` → red FAILED card with collapsible `<details>` log tail
- **Hidden for idle projects**: partial short-circuits on `wiki_refresh is None` or when both `in_progress=False` and `last_exit_code is None`.
- **No route change**: v0.8.6 already wired `wiki_refresh` into `ProjectStatus` and the existing `project_detail` route already passes `status` to the template. v0.8.7 is one `{% include %}` plus the partial.
- **Styled to match existing partials** (`scan_coverage`, `hotspots`): inline styles, pastel backgrounds, coloured left-borders. No new CSS classes, no new JS.

## Test plan

- [x] `tests/integration/test_ui_wiki_refresh.py` (+4):
  - Panel hidden when no `.refresh.lock` and no `.refresh.last`
  - Clean exit → green card, "N modules updated", no log-tail control
  - Crash → red FAILED card with each log-tail line rendered inside the `<details>` block
  - Live in-progress → blue card, phase, "N / M modules", current module (uses `pid=os.getpid()` so `_pid_alive` returns True without monkeypatching)
- [x] Full fast suite 1137 passing, ruff + format + mypy strict clean
- [x] Manual render: section lands between scan coverage and dependency graph, matches existing visual language