### PR TITLE
release(v0.8.8): HTMX live-polling on wiki_refresh panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.7-dashboard-bg-refresh.md)
-[![Version 0.8.7](https://img.shields.io/badge/version-0.8.7-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md)
+[![Version 0.8.8](https://img.shields.io/badge/version-0.8.8-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.8 (2026-04-24)** — HTMX live-polling on the `wiki_refresh` panel. The dashboard's bg-refresh panel (v0.8.7) now updates in place every ~2 s while a refresh is running — no page reload, no new CSS, no new JS beyond the HTMX script that was already loaded since phase 7. New public helper `libs.status.aggregator.build_wiki_refresh` lets the polling endpoint skip the full `build_project_status` pipeline, keeping each tick cheap. A new fragment route `GET /api/project/<slug>/wiki-refresh` re-renders just the partial; the outer wrapper's presence-or-absence of `hx-get` is the cancellation signal, so polling self-cancels the moment the refresh transitions to idle.
+
 **v0.8.7 (2026-04-24)** — Dashboard renders `wiki_refresh` panel. The FastAPI/HTMX per-project page (`/project/<slug>`) now draws a new "Wiki background refresh" section between scan coverage and the dependency graph: blue "Running" card with phase + progress bar + current module + pid when a refresh is in flight, green "clean", gray "cancelled (SIGTERM)", or red "FAILED" card (with collapsible log tail) otherwise. Hidden for projects that have never run a refresh. Closes the #1 known gap from v0.8.6: data model was ready, just needed rendering. No route change — `ProjectStatus.wiki_refresh` from v0.8.6 was already passed to the template; v0.8.7 adds one `{% include %}` plus a partial.
 
 **v0.8.6 (2026-04-24)** — MCP `lvdcp_status` surfaces bg refresh state. `ProjectStatus` gains `wiki_refresh: WikiBackgroundRefresh | None` — a nested block that mirrors `CopilotCheckReport.wiki_refresh_*` / `wiki_last_refresh_*` (live progress + last-run outcome + crash tail). Agents calling `lvdcp_status(path=…)` now see the same bg-refresh state `ctx project check` shows on the CLI, so they can decide "refresh or pack" without shelling out. Lazy import of `libs.copilot` keeps non-wiki consumers from paying the cost. No new deps.
@@ -80,6 +82,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md](docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md) (v0.8.8 — HTMX live-polling on the `wiki_refresh` panel)
 - [docs/release/2026-04-24-v0.8.7-dashboard-bg-refresh.md](docs/release/2026-04-24-v0.8.7-dashboard-bg-refresh.md) (v0.8.7 — Dashboard renders `wiki_refresh` panel)
 - [docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md](docs/release/2026-04-24-v0.8.6-mcp-bg-refresh.md) (v0.8.6 — MCP `lvdcp_status` surfaces bg refresh state)
 - [docs/release/2026-04-24-v0.8.5-log-tail.md](docs/release/2026-04-24-v0.8.5-log-tail.md) (v0.8.5 — Error log tail)
@@ -442,6 +445,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.5** (done) — Error log tail: on a non-clean, non-SIGTERM exit the runner captures the current run's last ~20 lines of `.refresh.log` into `.refresh.last.log_tail`, and `ctx project check` renders them as an indented block under the `FAILED exit=…` last-run hint — so diagnosing a crashed refresh no longer needs a second `cat .refresh.log`. Closes the "no error-tail surface" gap from v0.8.4. No new deps.
 - **v0.8.6** (done) — MCP `lvdcp_status` surfaces bg refresh state. `ProjectStatus.wiki_refresh` (nested) mirrors the `CopilotCheckReport.wiki_refresh_*` / `wiki_last_refresh_*` fields so agents and dashboards see the same bg-refresh snapshot the CLI shows (live progress, last-run outcome, crash tail). Lazy import of `libs.copilot` keeps non-wiki consumers cost-free. No new deps.
 - **v0.8.7** (done) — Dashboard renders `wiki_refresh` panel. New partial `apps/ui/templates/partials/wiki_refresh.html.j2` draws the v0.8.6 `ProjectStatus.wiki_refresh` field in four visually distinct shapes (running / clean / SIGTERM / FAILED-with-log-tail) on `/project/<slug>`. Hidden for projects that never ran a refresh. Closes the #1 known gap from v0.8.6 (data model ready, no UI). One `{% include %}`, no route change, no new deps.
+- **v0.8.8** (done) — HTMX live-polling on the `wiki_refresh` panel. New public helper `libs.status.aggregator.build_wiki_refresh` + new fragment route `GET /api/project/<slug>/wiki-refresh` let the panel update in place every ~2 s while a refresh runs. Outer wrapper's `hx-get` absence after completion self-cancels polling — no JS, no SSE, no `hx-swap-oob`. Cadence matches `ctx project check --watch` (v0.8.3). Closes the #1 known gap from v0.8.7.
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/ui/routes/project.py
+++ b/apps/ui/routes/project.py
@@ -9,7 +9,12 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from libs.core.projects_config import load_config
 from libs.obsidian.models import ObsidianFileInfo, ObsidianModuleData, ObsidianSymbolInfo
-from libs.status.aggregator import build_project_status, build_workspace_status, resolve_config_path
+from libs.status.aggregator import (
+    build_project_status,
+    build_wiki_refresh,
+    build_workspace_status,
+    resolve_config_path,
+)
 from libs.status.budget import compute_budget_status
 from libs.status.models import WorkspaceStatus
 from libs.summaries.store import SummaryStore, resolve_default_store_path
@@ -55,6 +60,31 @@ def project_detail(slug: str, request: Request) -> _TemplateResponse:
             "summaries": summaries,
             "obsidian_config": obsidian_config,
         },
+    )
+
+
+@router.get("/api/project/{slug}/wiki-refresh", response_class=HTMLResponse)
+def wiki_refresh_fragment(slug: str, request: Request) -> _TemplateResponse:
+    """HTMX polling endpoint: render just the wiki_refresh partial.
+
+    Called every ~2 s by the partial's outer wrapper while a refresh is
+    in progress (``hx-get`` on ``#wiki-refresh-panel``). Builds only the
+    ``WikiBackgroundRefresh`` snapshot — not the full ``ProjectStatus``
+    — so polling stays cheap even during a live refresh. When the
+    refresh transitions to idle, the response has no ``hx-get`` on the
+    outer wrapper and HTMX stops the timer.
+    """
+    ws = build_workspace_status()
+    root = _find_project_root_by_slug(ws, slug)
+    if root is None:
+        raise HTTPException(status_code=404, detail=f"project not found: {slug}")
+
+    wr = build_wiki_refresh(Path(root))
+    templates = request.app.state.templates
+    return templates.TemplateResponse(  # type: ignore[no-any-return]
+        request=request,
+        name="partials/wiki_refresh.html.j2",
+        context={"wr": wr, "slug": slug},
     )
 
 

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -22,7 +22,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.7</span>
+        <span>LV_DCP Dashboard &bull; v0.8.8</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/ui/templates/partials/wiki_refresh.html.j2
+++ b/apps/ui/templates/partials/wiki_refresh.html.j2
@@ -1,17 +1,31 @@
 {#
   Wiki background refresh panel.
 
-  Renders three visually distinct shapes driven by `status.wiki_refresh`:
+  Context parameters (set via ``{% with wr=..., slug=... %}`` at the
+  call site, so this partial is renderable both from the full
+  ``project.html.j2`` page and from the HTMX polling fragment endpoint):
 
-    1. Running   — blue left-border card with pulsing dot, phase, progress
-                   bar, current module, pid.
-    2. Clean/SIGTERM/Failed — green/gray/red card summarising last run.
-    3. Nothing to say — partial renders nothing (aggregator returns None
-       when there is no lock, no .refresh.last, or the copilot import
-       itself fails; we also skip when the snapshot is populated but has
-       no in-progress state AND no last-run record).
+    - ``wr``   : ``WikiBackgroundRefresh | None`` — the snapshot to render.
+    - ``slug`` : project slug — used for the HTMX polling URL.
+
+  Shapes (rendered inside a stable outer wrapper so HTMX can swap the
+  whole element via ``hx-swap=outerHTML`` every ~2 s during a live
+  refresh):
+
+    1. nothing to render (wr is None, or populated but idle with no
+       last-run record) → outer wrapper is emitted empty, with no
+       ``hx-get`` so HTMX is silent.
+    2. Running   → blue left-border card with pulsing dot, phase,
+       progress bar, current module, pid. Outer wrapper carries
+       ``hx-get`` + ``hx-trigger="every 2s"`` + ``hx-swap="outerHTML"``
+       so the client polls ``/api/project/<slug>/wiki-refresh``.
+    3. Clean / SIGTERM / Failed → green/gray/red static card. Outer
+       wrapper has no ``hx-get`` so polling stops.
+
+  Transition "running → done" works because HTMX swaps the full outer
+  element: the new DOM has no ``hx-get`` → no further timers fire.
 #}
-{% set wr = status.wiki_refresh %}
+<div id="wiki-refresh-panel"{% if wr and wr.in_progress and slug %} hx-get="/api/project/{{ slug }}/wiki-refresh" hx-trigger="every 2s" hx-swap="outerHTML"{% endif %}>
 {% if wr and (wr.in_progress or wr.last_exit_code is not none) %}
 <section class="section">
     <h2>Wiki background refresh</h2>
@@ -72,3 +86,4 @@
     {% endif %}
 </section>
 {% endif %}
+</div>

--- a/apps/ui/templates/project.html.j2
+++ b/apps/ui/templates/project.html.j2
@@ -20,7 +20,9 @@
         {% include "partials/scan_coverage.html.j2" %}
     {% endwith %}
 
-    {% include "partials/wiki_refresh.html.j2" %}
+    {% with wr=status.wiki_refresh, slug=status.card.slug %}
+        {% include "partials/wiki_refresh.html.j2" %}
+    {% endwith %}
 
     <section class="section">
         <h2>Dependency graph</h2>

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.7",
+    "version": "0.8.8",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md
+++ b/docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md
@@ -1,0 +1,146 @@
+# LV_DCP v0.8.8 — HTMX live-polling on the `wiki_refresh` panel
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** the dashboard panel shipped in v0.8.7 now updates in place
+every ~2 s while a refresh is running, then stops polling the moment
+the refresh completes — no page refresh, no new CSS, no new JS beyond
+the already-loaded HTMX. Closes the #1 known gap from v0.8.7.
+
+## Why
+
+v0.8.7 drew the `wiki_refresh` panel on `/project/<slug>`, but the
+page only refreshed the state on a full reload. A human watching a
+long refresh had to hit F5 repeatedly to see progress advance.
+v0.8.8 wires the existing HTMX script that's already in `base.html.j2`
+to poll a new fragment endpoint, and uses the outer wrapper's presence
+or absence of `hx-get` as a self-cancelling control channel.
+
+## Shipped
+
+### New public helper: `libs.status.aggregator.build_wiki_refresh`
+
+`_build_wiki_refresh` had been private from v0.8.6. v0.8.8 promotes it
+to public `build_wiki_refresh(root)` so the fragment endpoint can
+build **just** the `WikiBackgroundRefresh` sliver — skipping the
+graph, sparklines, hotspots, and coverage computations — every 2 s.
+Polling stays cheap even during a live refresh.
+
+### New route: `GET /api/project/{slug}/wiki-refresh`
+
+Returns just the re-rendered partial (no `<html>`/`<body>`/`<header>`).
+404 for an unknown slug, same contract as `/project/{slug}`. Used by
+HTMX's `hx-get` as the polling target.
+
+### Refactored partial: stable outer wrapper + conditional polling attrs
+
+```html
+<div id="wiki-refresh-panel"
+     {%- if wr.in_progress and slug %}
+       hx-get="/api/project/{{ slug }}/wiki-refresh"
+       hx-trigger="every 2s"
+       hx-swap="outerHTML"
+     {%- endif %}>
+  {# … panel body … #}
+</div>
+```
+
+- While `in_progress`, the wrapper carries polling attributes — HTMX
+  fires a GET every 2 s.
+- When the refresh transitions to idle, the new fragment response has
+  **no** `hx-get` on the wrapper, HTMX's `outerHTML` swap replaces the
+  whole element, and the timer is gone with it. Self-cancelling — no
+  `hx-swap-oob`, no custom JS.
+
+The partial now takes `wr` + `slug` as context parameters instead of
+reading `status.wiki_refresh` / `status.card.slug` directly, so the
+same template renders from both the full page and the fragment
+endpoint.
+
+### `project.html.j2` wrapping
+
+```jinja
+{% with wr=status.wiki_refresh, slug=status.card.slug %}
+    {% include "partials/wiki_refresh.html.j2" %}
+{% endwith %}
+```
+
+Same visual output as v0.8.7 when idle. During a refresh, the panel
+now updates in place.
+
+## Tests
+
+**+5 integration tests** in `tests/integration/test_ui_wiki_refresh.py`
+(total 9 for this file; the existing 4 from v0.8.7 still pass with no
+changes):
+
+- `test_project_detail_adds_htmx_polling_while_running` — full page
+  render during a refresh carries `hx-get`, `hx-trigger="every 2s"`,
+  `hx-swap="outerHTML"`, `id="wiki-refresh-panel"`.
+- `test_project_detail_omits_htmx_polling_when_idle` — clean last run,
+  wrapper present, **no** `hx-get` on the wrapper's opening tag
+  (sliced to the tag itself, not the whole document).
+- `test_wiki_refresh_fragment_endpoint_returns_running_shape` —
+  `GET /api/project/<slug>/wiki-refresh` during a refresh returns the
+  running card + polling attributes + no page chrome (`<html>`,
+  `<body>`).
+- `test_wiki_refresh_fragment_endpoint_stops_polling_when_idle` —
+  fragment response for an idle project has no `hx-get` anywhere →
+  polling halts on swap.
+- `test_wiki_refresh_fragment_endpoint_returns_404_for_unknown_slug`
+  — same 404 contract as `/project/<slug>`.
+
+**Total suite: 1142 passing (+5 vs v0.8.7).** Ruff + format + mypy
+strict clean across 374 source files.
+
+## Design notes
+
+- **Why outer-wrapper presence as the cancellation signal.** HTMX's
+  `hx-swap="outerHTML"` replaces the element carrying the `hx-get`.
+  After the swap, the old element is gone and so is its timer. No
+  extra attribute, no `hx-swap-oob`, no JS — the server decides when
+  to stop by simply not emitting the attribute. Minimal surface area.
+- **Why 2 s, not 1 s or 5 s.** 2 s matches the CLI's `ctx project
+  check --watch` default interval (v0.8.3), so the UI and CLI refresh
+  at the same cadence. Short enough to feel live, long enough not to
+  hammer the lock file.
+- **Why skip the full `build_project_status` in the fragment route.**
+  The polling endpoint runs every 2 s; calling `build_project_status`
+  would re-walk the graph and recompute sparklines each tick. The new
+  `build_wiki_refresh(root)` is ~one `read_status` call — an atomic
+  lock-file read plus a `.refresh.last` JSON parse.
+- **`{% with %}` over direct `status.card.slug` in the partial.**
+  Passing `wr` and `slug` as local names makes the partial usable
+  from *any* context (not just one where a full `ProjectStatus`
+  exists). Cleaner contract, zero runtime cost.
+- **No `main.py` / router registration change.** The new route lives
+  on the existing `routes.project` router that was already registered
+  in `apps/ui/main.py`.
+
+## Migration / compat
+
+- No DB migration, no config knob, no new deps. HTMX was already
+  loaded via `base.html.j2` since phase 7 for the Obsidian sync
+  button.
+- `build_wiki_refresh` is now a public module attribute of
+  `libs.status.aggregator`. The old private name `_build_wiki_refresh`
+  is gone; the only existing caller (inside the same module) was
+  updated in the same commit.
+- Template partial API changed: `wiki_refresh.html.j2` now reads `wr`
+  + `slug` from its context rather than walking `status.*`. Only
+  existing caller (`project.html.j2`) was updated in the same commit.
+
+## Known gaps (carry-forward)
+
+- **No error backoff.** If the fragment endpoint starts 500-ing
+  mid-poll (shouldn't happen — best-effort `None` return everywhere),
+  HTMX keeps polling every 2 s. `hx-trigger="every 2s, load"` with an
+  error-class rule could throttle, but it's premature.
+- **Still no transition toast.** The panel smoothly swaps
+  running → FAILED without any extra notification. A one-time
+  `hx-swap-oob` flash banner on the crash transition would be a cheap
+  follow-up.
+- **Still no auto-heal / retry.** Same as v0.8.5/6/7.
+- **No SSE alternative.** Polling is fine at 2 s, but an SSE stream
+  would halve the latency. HTMX ext support for SSE is opt-in; not
+  worth it for this cadence.

--- a/libs/status/aggregator.py
+++ b/libs/status/aggregator.py
@@ -213,7 +213,7 @@ def build_project_status(project_root: Path) -> ProjectStatus:
 
     hotspots = _build_hotspots(root)
     coverage = _build_scan_coverage(root)
-    wiki_refresh = _build_wiki_refresh(root)
+    wiki_refresh = build_wiki_refresh(root)
 
     return ProjectStatus(
         card=card,
@@ -227,15 +227,20 @@ def build_project_status(project_root: Path) -> ProjectStatus:
     )
 
 
-def _build_wiki_refresh(root: Path) -> WikiBackgroundRefresh | None:
-    """Assemble the MCP-facing background wiki-refresh snapshot.
+def build_wiki_refresh(root: Path) -> WikiBackgroundRefresh | None:
+    """Assemble the bg wiki-refresh snapshot exposed on ``ProjectStatus``.
 
     Thin mapping over :func:`libs.copilot.wiki_background.read_status` —
     flattens the nested ``last_run`` record into ``last_*`` fields so
-    agents calling ``lvdcp_status`` don't need to know the internal
-    dataclass shape. Returns ``None`` on any read error (best-effort: a
-    missing or torn lock file shouldn't break the whole status
-    payload).
+    callers (MCP agents, HTMX fragment endpoint, CLI renderers) don't
+    need to know the internal dataclass shape. Returns ``None`` on any
+    read error (best-effort: a missing or torn lock file shouldn't
+    break the whole status payload).
+
+    Public from v0.8.8 onwards so the dashboard's HTMX polling endpoint
+    can build *just* this sliver of state without paying for the full
+    ``build_project_status`` pipeline (graph, sparklines, hotspots,
+    coverage) every ~2 s during a live refresh.
     """
     try:
         # Lazy import: ``libs.copilot`` pulls in the scanning stack, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.7"
+version = "0.8.8"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/test_ui_wiki_refresh.py
+++ b/tests/integration/test_ui_wiki_refresh.py
@@ -125,29 +125,31 @@ async def test_project_detail_renders_crash_with_log_tail(
     assert "RuntimeError: upstream 504" in response.text
 
 
-@pytest.mark.asyncio
-async def test_project_detail_renders_live_in_progress(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Live lock with our own PID → blue 'Running' card with phase and progress."""
-    project = _seed_project(tmp_path, monkeypatch)
+def _seed_running_lock(project: Path, *, phase: str = "generating") -> None:
+    """Write a `.refresh.lock` pointing at the test process so _pid_alive=True."""
     lock_dir = project / ".context" / "wiki"
     lock_dir.mkdir(parents=True, exist_ok=True)
-    lock = lock_dir / ".refresh.lock"
-    # Use the test process's own PID so `_pid_alive` returns True without
-    # having to monkeypatch anything.
-    lock.write_text(
+    (lock_dir / ".refresh.lock").write_text(
         json.dumps(
             {
                 "pid": os.getpid(),
                 "started_at": time.time(),
-                "phase": "generating",
+                "phase": phase,
                 "modules_total": 5,
                 "modules_done": 2,
                 "current_module": "libs/foo",
             }
         )
     )
+
+
+@pytest.mark.asyncio
+async def test_project_detail_renders_live_in_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Live lock with our own PID → blue 'Running' card with phase and progress."""
+    project = _seed_project(tmp_path, monkeypatch)
+    _seed_running_lock(project)
 
     app = create_app()
     transport = httpx.ASGITransport(app=app)
@@ -160,3 +162,107 @@ async def test_project_detail_renders_live_in_progress(
     assert "phase: generating" in response.text
     assert "2 / 5 modules" in response.text
     assert "libs/foo" in response.text
+
+
+# -------- v0.8.8: HTMX polling fragment -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_project_detail_adds_htmx_polling_while_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Full page render while running must emit hx-get + hx-trigger on the wrapper."""
+    project = _seed_project(tmp_path, monkeypatch)
+    _seed_running_lock(project)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/project/{_slug(project)}")
+
+    assert response.status_code == 200
+    # The wrapper must carry the polling attributes so HTMX starts its
+    # timer on page load — the whole point of v0.8.8.
+    assert f'hx-get="/api/project/{_slug(project)}/wiki-refresh"' in response.text
+    assert 'hx-trigger="every 2s"' in response.text
+    assert 'hx-swap="outerHTML"' in response.text
+    assert 'id="wiki-refresh-panel"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_project_detail_omits_htmx_polling_when_idle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No running refresh → wrapper has NO hx-get, so HTMX stays silent."""
+    project = _seed_project(tmp_path, monkeypatch)
+    # Seed a clean last-run record so the section renders — we want to
+    # verify the wrapper is present but without polling attributes.
+    write_last_refresh(project, exit_code=0, modules_updated=3, elapsed_seconds=2.5)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/project/{_slug(project)}")
+
+    assert response.status_code == 200
+    assert 'id="wiki-refresh-panel"' in response.text
+    # Slice to just the wrapper's opening tag to be sure no hx-get on it.
+    panel_slice = response.text.split('id="wiki-refresh-panel"', 1)[1].split(">", 1)[0]
+    assert "hx-get=" not in panel_slice
+    assert "Last refresh: clean" in response.text
+
+
+@pytest.mark.asyncio
+async def test_wiki_refresh_fragment_endpoint_returns_running_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /api/project/<slug>/wiki-refresh during a refresh returns running HTML + polling."""
+    project = _seed_project(tmp_path, monkeypatch)
+    _seed_running_lock(project)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/api/project/{_slug(project)}/wiki-refresh")
+
+    assert response.status_code == 200
+    # Fragment must include the wrapper + hx-get so HTMX keeps polling.
+    assert 'id="wiki-refresh-panel"' in response.text
+    assert f'hx-get="/api/project/{_slug(project)}/wiki-refresh"' in response.text
+    assert "Running" in response.text
+    assert "phase: generating" in response.text
+    # Fragment must NOT be a full HTML page — no <html>/<body>/<header>.
+    assert "<html" not in response.text
+    assert "<body" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_wiki_refresh_fragment_endpoint_stops_polling_when_idle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the refresh completes, the fragment response has NO hx-get → polling halts."""
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=7, elapsed_seconds=4.2)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/api/project/{_slug(project)}/wiki-refresh")
+
+    assert response.status_code == 200
+    assert 'id="wiki-refresh-panel"' in response.text
+    assert "hx-get=" not in response.text
+    assert "Last refresh: clean" in response.text
+
+
+@pytest.mark.asyncio
+async def test_wiki_refresh_fragment_endpoint_returns_404_for_unknown_slug(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unknown project → 404, same contract as /project/<slug>."""
+    _seed_project(tmp_path, monkeypatch)
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/project/does-not-exist/wiki-refresh")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- `libs.status.aggregator.build_wiki_refresh` promoted from private (cheap slice — no graph/sparklines/hotspots/coverage rebuild per tick)
- New `GET /api/project/{slug}/wiki-refresh` fragment endpoint (partial only, no page chrome; 404 parity with `/project/{slug}`)
- Partial refactored to take `wr` + `slug` as context params; stable outer `#wiki-refresh-panel` wrapper carries `hx-get` + `hx-trigger="every 2s"` + `hx-swap="outerHTML"` **only** while `in_progress` — when the refresh transitions to idle, the response has no `hx-get`, the outerHTML swap replaces the element, and HTMX's timer dies with it (self-cancelling; no `hx-swap-oob`, no custom JS)

Closes the #1 known gap from v0.8.7 (no in-place progress updates).

## Test plan

- [x] +5 integration tests in `tests/integration/test_ui_wiki_refresh.py`:
  - `test_project_detail_adds_htmx_polling_while_running`
  - `test_project_detail_omits_htmx_polling_when_idle`
  - `test_wiki_refresh_fragment_endpoint_returns_running_shape`
  - `test_wiki_refresh_fragment_endpoint_stops_polling_when_idle`
  - `test_wiki_refresh_fragment_endpoint_returns_404_for_unknown_slug`
- [x] **Total suite: 1142 passing** (+5 vs v0.8.7); the 4 existing `test_ui_wiki_refresh.py` tests still green unchanged
- [x] `make lint` / `make format` / `make typecheck` clean across 374 source files

## Design notes

- **Outer-wrapper-attribute presence as cancellation signal.** `hx-swap="outerHTML"` replaces the element carrying the `hx-get`. The server decides when to stop by simply not emitting the attribute. Minimal surface area.
- **2 s cadence** matches `ctx project check --watch` (v0.8.3) so UI and CLI refresh at the same rhythm.
- **No main.py change, no new deps, no DB migration.** HTMX was already loaded via `base.html.j2` since phase 7 (Obsidian sync button).

Release notes: [`docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md`](docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)