### PR TITLE
release(v0.8.11): recovery toast on wiki_refresh degraded → normal transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.10-error-backoff.md)
-[![Version 0.8.10](https://img.shields.io/badge/version-0.8.10-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.11-recovery-toast.md)
+[![Version 0.8.11](https://img.shields.io/badge/version-0.8.11-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.11 (2026-04-24)** — Recovery toast on the `wiki_refresh` degraded → normal transition. Symmetric to v0.8.9's red crash toast: on the exact polling tick that flips the panel out of degraded mode (v0.8.10), the fragment response also carries a green `hx-swap-oob` banner into `#toast-region` so scrolled-away users notice the self-heal. Detection is pure-HTMX: the degraded wrapper echoes `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`, HTMX sends the marker on the next poll, the route sees the header on a now-successful assembly and flips a one-shot toast on. The new successful wrapper omits the marker so the toast fires exactly once per recovery event. No cookies, no session store, no JS state. Closes the top known gap from v0.8.10 (silent self-heal).
+
 **v0.8.10 (2026-04-24)** — Error-backoff shell on the `wiki_refresh` polling endpoint. The `/api/project/{slug}/wiki-refresh` route now wraps its status-assembly path in a try/except: on any internal failure it returns a 200 response carrying the partial in degraded mode — a yellow "refresh status unavailable" card with `hx-trigger="every 30s"` instead of `every 2s`. Closes two failure modes that predated the contract: (a) a 500 during polling caused HTMX to hammer the endpoint at the original 2 s cadence; (b) a `build_wiki_refresh` returning `None` silently stripped `hx-get` from the wrapper, freezing the panel until a full page reload. The 404-for-unknown-slug contract is preserved via `except HTTPException: raise`, and full-page `/project/<slug>` still 500s on genuine errors — the degraded shell is scoped to the polling endpoint only. Closes the first operational known gap from v0.8.8.
 
 **v0.8.9 (2026-04-24)** — One-shot crash toast on the `wiki_refresh` panel. The HTMX polling tick that flips the panel from *running* → *FAILED* now also carries an `hx-swap-oob` flash banner that HTMX appends into a new fixed-position `#toast-region` drop zone added to `base.html.j2`. Four predicates gate the emission — `HX-Request` header, refresh finished and non-live, `last_exit_code` a real crash (not `0`/`143`), `last_completed_at` within 15 s of now — so the toast fires exactly once per crash event, never on full page reload, never on SIGTERM cancellation, never on a manual `curl`. No new JS, no new deps, no route changes — fragment endpoint just adds a `show_crash_toast` flag to the template context. Closes the second known gap from v0.8.8 (no transition notification).
@@ -86,6 +88,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.11-recovery-toast.md](docs/release/2026-04-24-v0.8.11-recovery-toast.md) (v0.8.11 — Recovery toast on `wiki_refresh` degraded → normal)
 - [docs/release/2026-04-24-v0.8.10-error-backoff.md](docs/release/2026-04-24-v0.8.10-error-backoff.md) (v0.8.10 — Error-backoff shell on `wiki_refresh` polling endpoint)
 - [docs/release/2026-04-24-v0.8.9-crash-toast.md](docs/release/2026-04-24-v0.8.9-crash-toast.md) (v0.8.9 — One-shot crash toast on `wiki_refresh` panel)
 - [docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md](docs/release/2026-04-24-v0.8.8-wiki-refresh-htmx.md) (v0.8.8 — HTMX live-polling on the `wiki_refresh` panel)
@@ -454,6 +457,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.8** (done) — HTMX live-polling on the `wiki_refresh` panel. New public helper `libs.status.aggregator.build_wiki_refresh` + new fragment route `GET /api/project/<slug>/wiki-refresh` let the panel update in place every ~2 s while a refresh runs. Outer wrapper's `hx-get` absence after completion self-cancels polling — no JS, no SSE, no `hx-swap-oob`. Cadence matches `ctx project check --watch` (v0.8.3). Closes the #1 known gap from v0.8.7.
 - **v0.8.9** (done) — One-shot crash toast on the `wiki_refresh` panel. New fixed-position `#toast-region` drop zone in `base.html.j2`; the polling fragment endpoint emits an `hx-swap-oob="beforeend:#toast-region"` red flash banner on the exact tick that flips the panel to `FAILED`. Gated by four predicates (`HX-Request` + non-live + real-crash exit + `last_completed_at` within 15 s) so the toast fires exactly once per crash event and stays silent on full page reload, SIGTERM cancel, clean completion, and manual `curl`. Closes the second known gap from v0.8.8.
 - **v0.8.10** (done) — Error-backoff shell on the `wiki_refresh` polling endpoint. `/api/project/{slug}/wiki-refresh` now wraps its status-assembly path in try/except: on any internal exception it returns 200 with the partial in degraded mode (yellow "refresh status unavailable" card + `hx-trigger="every 30s"` instead of `every 2s`). `except HTTPException: raise` preserves the 404-for-unknown-slug contract. Full-page `/project/<slug>` still 500s on real errors, so the degraded shell is scoped to continuous polling only. Closes the first operational known gap from v0.8.8 (500 mid-poll → HTMX hammers at 2 s; silent `None` → polling stops forever).
+- **v0.8.11** (done) — Recovery toast on `wiki_refresh` degraded → normal. Symmetric to v0.8.9's red crash toast: on the exact poll that flips the panel out of degraded mode, the fragment carries a green `hx-swap-oob` banner into `#toast-region`. Detection is pure-HTMX: the degraded wrapper sets `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`; the route sees the marker on a now-successful assembly and flips `show_recovery_toast=True` for exactly one response. The new successful wrapper omits the marker → no replay. No cookies, no session store, no JS. Closes the top known gap from v0.8.10 (silent self-heal).
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/ui/routes/project.py
+++ b/apps/ui/routes/project.py
@@ -39,6 +39,15 @@ _CRASH_TOAST_FRESH_SECONDS = 15.0
 #: an unexpected crash and does trigger the toast.
 _NON_CRASH_EXIT_CODES: frozenset[int] = frozenset({0, 143})
 
+#: Request header the v0.8.10 degraded wrapper echoes on its next
+#: HTMX poll. When a subsequent fetch reaches this route *without* an
+#: internal exception, the presence of this header tells us we just
+#: transitioned degraded → normal, so the response emits a green
+#: recovery toast alongside the fresh panel. The degraded wrapper
+#: sets it via ``hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`` —
+#: pure HTMX, no cookies, no server-side session state.
+_WAS_DEGRADED_HEADER = "X-LV-DCP-Was-Degraded"
+
 
 def _find_project_root_by_slug(workspace: WorkspaceStatus, slug: str) -> str | None:
     for card in workspace.projects:
@@ -114,6 +123,34 @@ def _should_flash_crash_toast(wr: WikiBackgroundRefresh | None, request: Request
     return (time.time() - wr.last_completed_at) <= _CRASH_TOAST_FRESH_SECONDS
 
 
+def _should_flash_recovery_toast(request: Request) -> bool:
+    """Decide whether the fragment response carries a one-shot recovery toast.
+
+    Fires on the exact polling tick that flips ``degraded → normal`` —
+    i.e. the first successful status assembly after one or more
+    consecutive degraded responses. Two conditions must hold:
+
+    1. ``HX-Request: true`` header is present — rules out full page
+       loads and manual ``curl`` hits. A user navigating to
+       ``/project/<slug>`` after a long-past recovery never sees the
+       flash.
+    2. The request carries the :data:`_WAS_DEGRADED_HEADER` marker —
+       set by HTMX on polls fired from a degraded wrapper (via the
+       ``hx-headers`` attribute added in the partial). Absent on any
+       poll fired from a normal / running / idle wrapper, so the
+       toast fires exactly once per recovery event.
+
+    The marker is a pure-HTMX round trip: no cookie, no session, no
+    memory. That makes worker restarts, multiple browser tabs, and
+    curl-based testing trivially correct — each element tracks its
+    own degraded/normal state via the HTML attribute HTMX rewrites on
+    every swap.
+    """
+    if request.headers.get("HX-Request", "").lower() != "true":
+        return False
+    return request.headers.get(_WAS_DEGRADED_HEADER, "").lower() == "true"
+
+
 @router.get("/api/project/{slug}/wiki-refresh", response_class=HTMLResponse)
 def wiki_refresh_fragment(slug: str, request: Request) -> _TemplateResponse:
     """HTMX polling endpoint: render just the wiki_refresh partial.
@@ -144,6 +181,15 @@ def wiki_refresh_fragment(slug: str, request: Request) -> _TemplateResponse:
     ``hx-get`` from the wrapper, stopping polling forever for a
     transient failure. Explicit 404 for unknown slug is preserved so
     genuine client-side bugs still surface.
+
+    **Recovery toast (v0.8.11+):** the degraded wrapper carries
+    ``hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`` so its next
+    HTMX poll echoes the marker back. When we see the marker on a
+    now-successful assembly it means we just self-healed — the
+    response adds a green OOB toast alongside the fresh panel so
+    scrolled-away users notice the recovery. The new successful
+    wrapper does NOT re-emit the marker, so subsequent polls don't
+    replay the toast. See :func:`_should_flash_recovery_toast`.
     """
     templates = request.app.state.templates
     try:
@@ -180,6 +226,7 @@ def wiki_refresh_fragment(slug: str, request: Request) -> _TemplateResponse:
             "wr": wr,
             "slug": slug,
             "show_crash_toast": _should_flash_crash_toast(wr, request),
+            "show_recovery_toast": _should_flash_recovery_toast(request),
         },
     )
 

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -28,7 +28,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.10</span>
+        <span>LV_DCP Dashboard &bull; v0.8.11</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/ui/templates/partials/wiki_refresh.html.j2
+++ b/apps/ui/templates/partials/wiki_refresh.html.j2
@@ -22,6 +22,17 @@
       underlying infra recovers. Without this flag a transient error
       would either 500 (HTMX keeps hammering at 2 s) or silently drop
       ``hx-get`` (polling stops forever).
+    - ``show_recovery_toast`` : bool (optional, v0.8.11+) — set by the
+      fragment endpoint on the exact tick that flips degraded → normal.
+      Detection is pure-HTMX: the degraded wrapper carries an
+      ``hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`` marker that
+      HTMX echoes on the next fetch from that element; the route sees
+      the header on a now-successful assembly and flips this flag on
+      for the one response. The partial then emits a green
+      ``hx-swap-oob="beforeend:#toast-region"`` banner so scrolled-
+      away users notice the self-heal. The new successful wrapper
+      does NOT re-emit the marker, so the toast fires exactly once
+      per recovery event.
 
   Shapes (rendered inside a stable outer wrapper so HTMX can swap the
   whole element via ``hx-swap=outerHTML`` every ~2 s during a live
@@ -49,7 +60,7 @@
   without fast polling depending on whether a refresh is live).
 #}
 <div id="wiki-refresh-panel"
-  {%- if degraded and slug %} hx-get="/api/project/{{ slug }}/wiki-refresh" hx-trigger="every 30s" hx-swap="outerHTML"
+  {%- if degraded and slug %} hx-get="/api/project/{{ slug }}/wiki-refresh" hx-trigger="every 30s" hx-swap="outerHTML" hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'
   {%- elif wr and wr.in_progress and slug %} hx-get="/api/project/{{ slug }}/wiki-refresh" hx-trigger="every 2s" hx-swap="outerHTML"
   {%- endif %}>
 {% if degraded %}
@@ -145,6 +156,36 @@
             exited {{ wr.last_exit_code }}
             {% if wr.last_modules_updated is not none %} after {{ wr.last_modules_updated }} module{{ "s" if wr.last_modules_updated != 1 else "" }}{% endif %}.
             See the panel below for the log tail.
+        </div>
+    </div>
+    <button type="button"
+            onclick="this.parentElement.remove()"
+            aria-label="Dismiss"
+            style="background:transparent;border:0;color:#fff;opacity:0.8;cursor:pointer;font-size:18px;line-height:1;padding:0 2px;">&times;</button>
+</div>
+{% endif %}
+{% if show_recovery_toast and slug %}
+{# OOB flash banner for the degraded → normal transition (v0.8.11+). The
+   degraded wrapper carries ``hx-headers='{"X-LV-DCP-Was-Degraded":
+   "true"}'`` so the next HTMX poll round-trips the marker to the route.
+   When the route sees the marker on a now-successful assembly it sets
+   ``show_recovery_toast=True``. The new successful wrapper does NOT
+   emit the marker, so subsequent polls don't replay the toast. On a
+   full page reload the freshly rendered partial also omits the marker
+   (no HTMX session state survives), so a user who navigates after an
+   old recovery won't get re-flashed. ID is deterministic per-slug so
+   a pathological double-fetch during the same recovery replaces the
+   same toast instead of stacking duplicates. #}
+<div id="recovery-toast-{{ slug }}"
+     hx-swap-oob="beforeend:#toast-region"
+     style="pointer-events:auto;background:#2e7d32;color:#fff;padding:12px 16px;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.18);display:flex;align-items:flex-start;gap:12px;font-size:13px;line-height:1.4;">
+    <div style="flex:1;min-width:0;">
+        <div style="font-weight:bold;margin-bottom:2px;">
+            &#x2713; Wiki refresh status recovered
+        </div>
+        <div style="opacity:0.92;">
+            <code style="background:rgba(255,255,255,0.15);padding:1px 5px;border-radius:3px;color:#fff;">{{ slug }}</code>
+            is reachable again. Resuming normal polling.
         </div>
     </div>
     <button type="button"

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.11-recovery-toast.md
+++ b/docs/release/2026-04-24-v0.8.11-recovery-toast.md
@@ -1,0 +1,200 @@
+# LV_DCP v0.8.11 — recovery toast on the `wiki_refresh` degraded → normal transition
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** on the exact polling tick that flips the wiki-refresh panel
+from *degraded* → *normal*, the fragment response now also carries a
+green `hx-swap-oob` banner that HTMX appends into `#toast-region` —
+so a user who scrolled away during an incident notices when the infra
+self-heals. Symmetric to v0.8.9's red crash toast; closes the top
+known gap from v0.8.10.
+
+## Why
+
+v0.8.10 added a degraded shell with 30 s polling so the panel
+self-heals when the infra recovers — but the heal itself was silent.
+If a user was looking elsewhere (another tab, another project, or
+just away) the first degraded card they never saw and the first
+normal card that replaced it were both indistinguishable from a
+steady-state normal render. With long-running incidents that matters:
+the visible motion of the yellow card (when present) doesn't survive
+scroll, and without a flash there's no ambient signal to say "we're
+back."
+
+v0.8.11 adds the signal. Pure-HTMX, no cookies, no JS state, no
+server-side session store. A client-echoed header marks polls that
+came from a degraded wrapper; the route sees the marker on a
+now-successful assembly and flips a one-shot toast on.
+
+## Shipped
+
+### Partial: degraded wrapper gains an `hx-headers` marker
+
+```jinja
+<div id="wiki-refresh-panel"
+  {%- if degraded and slug %} hx-get="/api/project/{{ slug }}/wiki-refresh"
+      hx-trigger="every 30s" hx-swap="outerHTML"
+      hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'
+  …
+```
+
+HTMX's `hx-headers` attribute takes a JSON object and sends each
+key-value pair as a request header on every fetch from that element.
+Set on the degraded wrapper only — the normal running/idle/done
+wrappers omit it. One short attribute, no client-side state.
+
+### Route: a second gate helper mirrors `_should_flash_crash_toast`
+
+```python
+def _should_flash_recovery_toast(request: Request) -> bool:
+    if request.headers.get("HX-Request", "").lower() != "true":
+        return False
+    return request.headers.get(_WAS_DEGRADED_HEADER, "").lower() == "true"
+```
+
+Two predicates, both must hold:
+
+1. **`HX-Request: true` header present.** Rules out full page loads
+   and manual `curl` hits with a spoofed marker.
+2. **`X-LV-DCP-Was-Degraded: true` echoed from the client.** Set by
+   HTMX only on polls fired from a degraded wrapper.
+
+When the assembly succeeds (no exception → we're out of the
+try/except → route falls through to the normal response path) *and*
+both predicates hold, the response passes `show_recovery_toast=True`
+to the partial. The new successful wrapper does NOT include
+`hx-headers`, so subsequent polls from it don't re-echo the marker
+→ no replay.
+
+If the assembly fails again (still broken), the response re-renders
+the degraded wrapper which re-emits the marker. The next poll will
+try recovery detection again. No lost events.
+
+### Partial: green OOB toast block
+
+```jinja
+{% if show_recovery_toast and slug %}
+<div id="recovery-toast-{{ slug }}"
+     hx-swap-oob="beforeend:#toast-region"
+     style="…green banner with slug + 'is reachable again' + dismiss button…">
+    &#x2713; Wiki refresh status recovered
+</div>
+{% endif %}
+```
+
+Deterministic ID per-slug (no timestamp). A pathological double-fetch
+during the same recovery would hit the same ID and replace the toast
+instead of stacking duplicates. In practice the recovery response is
+emitted exactly once and the new wrapper has no marker, so only one
+toast per recovery event ever lands.
+
+## Tests
+
+**+5 integration tests** in `tests/integration/test_ui_wiki_refresh.py`
+(27 total for this file now; the 22 from v0.8.7-v0.8.10 still pass
+unchanged):
+
+- `test_degraded_wrapper_carries_was_degraded_marker_header` —
+  forced degraded response → body contains `hx-headers=` and
+  `X-LV-DCP-Was-Degraded`. Proves the round-trip premise holds.
+- `test_recovery_toast_emitted_when_was_degraded_header_present_and_now_recovered`
+  — successful assembly with `HX-Request: true` + `X-LV-DCP-Was-
+  Degraded: true` → body contains `id="recovery-toast-<slug>"`,
+  `hx-swap-oob="beforeend:#toast-region"`, "Wiki refresh status
+  recovered", AND the normal "Last refresh: clean" card, AND the
+  wrapper does NOT re-emit `hx-headers`.
+- `test_recovery_toast_absent_without_was_degraded_header` —
+  steady-state normal polling → no toast.
+- `test_recovery_toast_absent_when_still_degraded` — infra still
+  broken + marker present → response is still degraded, no toast,
+  but the marker is re-emitted on the new degraded wrapper so the
+  next poll can try again.
+- `test_recovery_toast_absent_on_non_htmx_full_page_load` — full-
+  page `/project/<slug>` with spoofed marker but no `HX-Request`
+  → no toast. Proves the `HX-Request` gate works.
+
+**Total suite: 1161 passing (+5 vs v0.8.10).** Ruff + format + mypy
+strict clean across 374 source files.
+
+## Design notes
+
+- **Why `hx-headers`, not a cookie or a session.** Cookies would leak
+  across tabs and survive navigation — both things we explicitly
+  don't want (a different tab in a different slug shouldn't inherit
+  degraded state; reopening the page shouldn't re-flash an old
+  recovery). A session store would require Redis or a background
+  worker for something that's fundamentally per-DOM-element state.
+  The HTMX attribute lives where it belongs: on the one element that
+  represents the degraded panel, and dies the moment HTMX swaps
+  that element for a normal one.
+- **Why two predicates, not four like the crash toast.** The crash
+  toast needed a freshness window because its trigger (`last_exit_
+  code` + `last_completed_at`) was persistent server-side state —
+  without freshness, a user reopening the page ten minutes after a
+  crash would get re-flashed. The recovery toast's trigger is
+  ephemeral client-side state (an HTML attribute) that's
+  automatically cleared by the recovery itself, so no freshness
+  window is needed. Simplicity is a design property.
+- **Why deterministic toast ID without a timestamp.** The recovery
+  event doesn't have a natural timestamp — there's no moment we can
+  point to and say "this is when the infra came back", because we
+  only know we recovered relative to a previous poll. Using
+  `recovery-toast-{slug}` makes double-fetch-during-same-recovery
+  self-idempotent (replaces the same DOM node), which is good
+  enough. If a user recovers, gets a new crash, recovers again, the
+  second recovery toast shares the same ID and replaces the first —
+  but by then the first is long dismissed (or the user saw it). Not
+  worth layering timestamps.
+- **Why a broad `X-LV-DCP-` prefix on the header name.** Matches
+  Kubernetes / AWS / Azure conventions for custom headers and makes
+  it obvious in logs that the header is application-defined. Bonus:
+  easy to grep for across both the frontend template and the backend
+  route.
+- **Why not also emit a toast on degraded → still-degraded with a
+  different error class.** Tempting ("still broken after 5 min?") but
+  quickly becomes its own UX design problem — throttle, escalate,
+  dismissability, etc. Scoping v0.8.11 to the one clear good signal
+  (self-heal) leaves room to add granularity later without painting
+  into a corner.
+- **Green 2e7d32 chosen to match the existing "clean" card.** Same
+  palette as the green "Last refresh: clean" card inside the panel —
+  users parse "green = good, red = bad" without needing to read the
+  text. Red for crash (v0.8.9), yellow for degraded (v0.8.10), green
+  for recovery (v0.8.11) — all three inline styles, consistent.
+
+## Migration / compat
+
+- No DB migration, no new deps, no routing changes. Header name and
+  template context parameter are new but both are opt-in from the
+  route side.
+- Partial's public context parameters now include optional
+  `show_recovery_toast: bool` (default falsy). Existing callers that
+  omit it get no toast (current behaviour of `project.html.j2`).
+- The `hx-headers` attribute on the degraded wrapper is new HTML —
+  backward-compatible for any client that ignores HTMX attributes
+  (e.g. `curl` or a screen reader). The header only matters when
+  HTMX is loaded AND the attribute is present.
+
+## Known gaps (carry-forward)
+
+- **No auto-dismiss.** Same as the crash and degraded toasts — manual
+  close only. A CSS `animation: fadeout 8s forwards` for the recovery
+  toast specifically could make sense (unlike crashes, a recovery is
+  transient good news; it doesn't benefit from sticking around).
+  Deferred for cross-toast consistency.
+- **No "duration of outage" label on the recovery toast.** "Is
+  reachable again after 3m 42s" would be informative but requires
+  the server to remember when the degraded stretch began. Same
+  trade-off as "why no session store" above — not worth the state.
+- **No telemetry for recovery events.** A simple structured-log
+  `event=wiki_refresh_recovered slug=…` would feed a future
+  observability story. Not shipped with v0.8.11 but a natural next
+  step; `log.warning` on the degraded path already exists so the
+  symmetric `log.info` on recovery is one line.
+- **No rate-limit on recovery detection.** If a pathological client
+  spoofed `X-LV-DCP-Was-Degraded: true` on every poll, every tick
+  would emit a toast. Pure-HTMX clients can't do this (HTMX owns the
+  attribute), but hand-rolled clients could. The server has no
+  backpressure — intentional, since the toast has no side effects
+  beyond DOM.
+- **No SSE alternative.** Same as v0.8.8-10 — polling stays.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.10"
+version = "0.8.11"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/test_ui_wiki_refresh.py
+++ b/tests/integration/test_ui_wiki_refresh.py
@@ -646,3 +646,163 @@ async def test_project_detail_full_page_still_500s_on_internal_error(
     assert response.status_code == 500
     # The degraded card must not leak into the error body.
     assert "Refresh status unavailable" not in response.text
+
+
+# -------- v0.8.11: recovery toast on degraded → normal transition ----
+
+
+@pytest.mark.asyncio
+async def test_degraded_wrapper_carries_was_degraded_marker_header(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Degraded shell emits ``hx-headers`` so the next HTMX poll round-trips the marker.
+
+    Without the marker the server would have no way to tell a
+    degraded→normal transition from a plain steady-state normal poll,
+    and the recovery toast could never fire.
+    """
+    _seed_project(tmp_path, monkeypatch)
+
+    import apps.ui.routes.project as project_route
+
+    def _boom() -> object:
+        raise RuntimeError("transient hiccup")
+
+    monkeypatch.setattr(project_route, "build_workspace_status", _boom)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/project/anything/wiki-refresh",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    # The hx-headers attribute carries the marker as JSON — HTMX echoes
+    # each key in the JSON object as a request header on the next fetch.
+    assert "hx-headers=" in response.text
+    assert "X-LV-DCP-Was-Degraded" in response.text
+    assert '"true"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_recovery_toast_emitted_when_was_degraded_header_present_and_now_recovered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """HX-Request + X-LV-DCP-Was-Degraded marker + successful assembly → green recovery toast."""
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=3, elapsed_seconds=1.5)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={
+                "HX-Request": "true",
+                "X-LV-DCP-Was-Degraded": "true",
+            },
+        )
+
+    assert response.status_code == 200
+    # Green recovery toast must be present with the OOB swap target.
+    assert f'id="recovery-toast-{_slug(project)}"' in response.text
+    assert 'hx-swap-oob="beforeend:#toast-region"' in response.text
+    assert "Wiki refresh status recovered" in response.text
+    # Normal clean card is still present — the panel swapped back to normal.
+    assert "Last refresh: clean" in response.text
+    # The new wrapper MUST NOT re-emit the marker, or the next poll would
+    # replay the toast on every tick. Confirm by slicing just the wrapper.
+    panel_slice = response.text.split('id="wiki-refresh-panel"', 1)[1].split(">", 1)[0]
+    assert "hx-headers" not in panel_slice
+
+
+@pytest.mark.asyncio
+async def test_recovery_toast_absent_without_was_degraded_header(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Steady-state normal polling never emits a recovery toast."""
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=2, elapsed_seconds=1.0)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    assert "Wiki refresh status recovered" not in response.text
+    assert "recovery-toast-" not in response.text
+    # Sanity: the normal clean card is still there.
+    assert "Last refresh: clean" in response.text
+
+
+@pytest.mark.asyncio
+async def test_recovery_toast_absent_when_still_degraded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Infra still broken → response stays degraded, no recovery toast even with the marker.
+
+    A degraded-to-degraded transition is still "broken", not "recovered".
+    The marker re-echoes on the next poll (still a degraded wrapper), so
+    when the infra eventually comes back the toast fires then.
+    """
+    _seed_project(tmp_path, monkeypatch)
+
+    import apps.ui.routes.project as project_route
+
+    def _boom() -> object:
+        raise RuntimeError("still broken")
+
+    monkeypatch.setattr(project_route, "build_workspace_status", _boom)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/project/anything/wiki-refresh",
+            headers={
+                "HX-Request": "true",
+                "X-LV-DCP-Was-Degraded": "true",
+            },
+        )
+
+    assert response.status_code == 200
+    # Still degraded.
+    assert "Refresh status unavailable" in response.text
+    # No recovery toast.
+    assert "Wiki refresh status recovered" not in response.text
+    assert "recovery-toast-" not in response.text
+    # Marker STILL on the wrapper so the next poll can try again.
+    assert "X-LV-DCP-Was-Degraded" in response.text
+
+
+@pytest.mark.asyncio
+async def test_recovery_toast_absent_on_non_htmx_full_page_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user navigating to /project/<slug> after an old recovery never sees the toast.
+
+    The full page path renders the partial with ``show_recovery_toast``
+    absent from the template context entirely, so even if a user
+    manually spoofed the marker header the page wouldn't flash.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=2, elapsed_seconds=1.0)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        # Full page load — note NO HX-Request header, despite the spoofed marker.
+        response = await client.get(
+            f"/project/{_slug(project)}",
+            headers={"X-LV-DCP-Was-Degraded": "true"},
+        )
+
+    assert response.status_code == 200
+    assert "Wiki refresh status recovered" not in response.text
+    assert "recovery-toast-" not in response.text

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "lv-dcp"
-version = "0.8.10"
+version = "0.8.11"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- **Green `hx-swap-oob` recovery banner** fires on the exact polling tick that flips the wiki-refresh panel out of degraded mode (v0.8.10) — symmetric to v0.8.9's red crash toast and yellow v0.8.10 degraded card. Red/yellow/green palette now covers crash / broken / recovered.
- **Pure-HTMX detection, no state**: the degraded wrapper carries `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`; the route sees the echoed header on a now-successful assembly and flips `show_recovery_toast=True` for exactly one response. The new successful wrapper drops the marker → no replay.
- **Closes the top known gap from v0.8.10** (silent self-heal). A user who scrolled away during an incident now gets an ambient "we recovered" flash.

## Test plan

- [x] `uv run pytest tests/integration/test_ui_wiki_refresh.py` — 27 passed (22 prior + 5 new)
- [x] `make lint` — ruff check + format clean
- [x] `make typecheck` — mypy strict clean across 374 source files
- [x] `make test` — 1161 passed (1 pre-existing Qdrant SSL-cert flake unrelated)
- [x] Version bumps: `pyproject.toml` 0.8.10→0.8.11, `apps/vscode/package.json` 0.8.10→0.8.11, `apps/ui/templates/base.html.j2` footer v0.8.10→v0.8.11
- [x] Release notes: `docs/release/2026-04-24-v0.8.11-recovery-toast.md`
- [x] README: badge, Status paragraph, release-notes list, roadmap bullet all updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)