### PR TITLE
release(v0.8.12): auto-dismiss for the recovery toast on wiki_refresh panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.11-recovery-toast.md)
-[![Version 0.8.11](https://img.shields.io/badge/version-0.8.11-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.12-toast-autodismiss.md)
+[![Version 0.8.12](https://img.shields.io/badge/version-0.8.12-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.12 (2026-04-24)** — Auto-dismiss for the recovery toast. The green "wiki refresh status recovered" banner (v0.8.11) now carries an inline `animation: lvdcp-toast-fadeout 8s forwards` so it fades and disappears ~8 s after it appears (6 s visible + 2 s fade). The red crash toast stays sticky — bad news needs acknowledgment, good news does not. Zero JS, no new deps; the `@keyframes` block is scoped to the `{% if show_recovery_toast %}` guard so normal idle polls ship zero fadeout CSS. The final keyframe flips `pointer-events: none` so the invisible end-state doesn't intercept clicks. Closes the top UX gap from v0.8.11 (transient good-news toast required a manual click).
+
 **v0.8.11 (2026-04-24)** — Recovery toast on the `wiki_refresh` degraded → normal transition. Symmetric to v0.8.9's red crash toast: on the exact polling tick that flips the panel out of degraded mode (v0.8.10), the fragment response also carries a green `hx-swap-oob` banner into `#toast-region` so scrolled-away users notice the self-heal. Detection is pure-HTMX: the degraded wrapper echoes `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`, HTMX sends the marker on the next poll, the route sees the header on a now-successful assembly and flips a one-shot toast on. The new successful wrapper omits the marker so the toast fires exactly once per recovery event. No cookies, no session store, no JS state. Closes the top known gap from v0.8.10 (silent self-heal).
 
 **v0.8.10 (2026-04-24)** — Error-backoff shell on the `wiki_refresh` polling endpoint. The `/api/project/{slug}/wiki-refresh` route now wraps its status-assembly path in a try/except: on any internal failure it returns a 200 response carrying the partial in degraded mode — a yellow "refresh status unavailable" card with `hx-trigger="every 30s"` instead of `every 2s`. Closes two failure modes that predated the contract: (a) a 500 during polling caused HTMX to hammer the endpoint at the original 2 s cadence; (b) a `build_wiki_refresh` returning `None` silently stripped `hx-get` from the wrapper, freezing the panel until a full page reload. The 404-for-unknown-slug contract is preserved via `except HTTPException: raise`, and full-page `/project/<slug>` still 500s on genuine errors — the degraded shell is scoped to the polling endpoint only. Closes the first operational known gap from v0.8.8.
@@ -88,6 +90,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.12-toast-autodismiss.md](docs/release/2026-04-24-v0.8.12-toast-autodismiss.md) (v0.8.12 — Auto-dismiss for the recovery toast)
 - [docs/release/2026-04-24-v0.8.11-recovery-toast.md](docs/release/2026-04-24-v0.8.11-recovery-toast.md) (v0.8.11 — Recovery toast on `wiki_refresh` degraded → normal)
 - [docs/release/2026-04-24-v0.8.10-error-backoff.md](docs/release/2026-04-24-v0.8.10-error-backoff.md) (v0.8.10 — Error-backoff shell on `wiki_refresh` polling endpoint)
 - [docs/release/2026-04-24-v0.8.9-crash-toast.md](docs/release/2026-04-24-v0.8.9-crash-toast.md) (v0.8.9 — One-shot crash toast on `wiki_refresh` panel)
@@ -458,6 +461,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.9** (done) — One-shot crash toast on the `wiki_refresh` panel. New fixed-position `#toast-region` drop zone in `base.html.j2`; the polling fragment endpoint emits an `hx-swap-oob="beforeend:#toast-region"` red flash banner on the exact tick that flips the panel to `FAILED`. Gated by four predicates (`HX-Request` + non-live + real-crash exit + `last_completed_at` within 15 s) so the toast fires exactly once per crash event and stays silent on full page reload, SIGTERM cancel, clean completion, and manual `curl`. Closes the second known gap from v0.8.8.
 - **v0.8.10** (done) — Error-backoff shell on the `wiki_refresh` polling endpoint. `/api/project/{slug}/wiki-refresh` now wraps its status-assembly path in try/except: on any internal exception it returns 200 with the partial in degraded mode (yellow "refresh status unavailable" card + `hx-trigger="every 30s"` instead of `every 2s`). `except HTTPException: raise` preserves the 404-for-unknown-slug contract. Full-page `/project/<slug>` still 500s on real errors, so the degraded shell is scoped to continuous polling only. Closes the first operational known gap from v0.8.8 (500 mid-poll → HTMX hammers at 2 s; silent `None` → polling stops forever).
 - **v0.8.11** (done) — Recovery toast on `wiki_refresh` degraded → normal. Symmetric to v0.8.9's red crash toast: on the exact poll that flips the panel out of degraded mode, the fragment carries a green `hx-swap-oob` banner into `#toast-region`. Detection is pure-HTMX: the degraded wrapper sets `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`; the route sees the marker on a now-successful assembly and flips `show_recovery_toast=True` for exactly one response. The new successful wrapper omits the marker → no replay. No cookies, no session store, no JS. Closes the top known gap from v0.8.10 (silent self-heal).
+- **v0.8.12** (done) — Auto-dismiss for the recovery toast. Inline `animation: lvdcp-toast-fadeout 8s forwards` on the green toast only (crash toast stays sticky) — 6 s at full opacity, 2 s fade to `opacity: 0` + `pointer-events: none`. Zero JS, no new deps, ~200 bytes of inline CSS added only when the toast renders. Locks in the red/sticky vs green/transient UX asymmetry: bad news demands acknowledgment, good news fades. Closes the top UX gap from v0.8.11.
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -28,7 +28,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.11</span>
+        <span>LV_DCP Dashboard &bull; v0.8.12</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/ui/templates/partials/wiki_refresh.html.j2
+++ b/apps/ui/templates/partials/wiki_refresh.html.j2
@@ -32,7 +32,10 @@
       ``hx-swap-oob="beforeend:#toast-region"`` banner so scrolled-
       away users notice the self-heal. The new successful wrapper
       does NOT re-emit the marker, so the toast fires exactly once
-      per recovery event.
+      per recovery event. **v0.8.12+:** the recovery toast carries
+      an inline ``animation: lvdcp-toast-fadeout 8s forwards`` so it
+      auto-dismisses after ~8 s (6 s visible + 2 s fade) — unlike
+      the crash toast which stays sticky until manually dismissed.
 
   Shapes (rendered inside a stable outer wrapper so HTMX can swap the
   whole element via ``hx-swap=outerHTML`` every ~2 s during a live
@@ -175,10 +178,28 @@
    (no HTMX session state survives), so a user who navigates after an
    old recovery won't get re-flashed. ID is deterministic per-slug so
    a pathological double-fetch during the same recovery replaces the
-   same toast instead of stacking duplicates. #}
+   same toast instead of stacking duplicates.
+
+   **Auto-dismiss (v0.8.12+).** Unlike the crash toast — which is bad
+   news the user needs to acknowledge and therefore stays sticky until
+   manually dismissed — the recovery toast is transient good news.
+   Requiring a manual click to clear a "we recovered" message is
+   actively annoying (the user has already moved on). The inline
+   ``animation: lvdcp-toast-fadeout 8s forwards`` holds the toast at
+   full opacity for 6 s (enough for a glance), fades over 2 s, and the
+   ``forwards`` fill-mode pins the end state so the toast stays
+   invisible AND ``pointer-events: none`` so it can't block clicks on
+   anything underneath. Dismiss button still works during the visible
+   window for users who want to clear it immediately. The keyframes
+   are inlined next to the toast so they're only present in the DOM
+   when the toast actually renders (no unused CSS on normal polls). #}
+<style>@keyframes lvdcp-toast-fadeout {
+    0%, 75% { opacity: 1; }
+    100% { opacity: 0; pointer-events: none; }
+}</style>
 <div id="recovery-toast-{{ slug }}"
      hx-swap-oob="beforeend:#toast-region"
-     style="pointer-events:auto;background:#2e7d32;color:#fff;padding:12px 16px;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.18);display:flex;align-items:flex-start;gap:12px;font-size:13px;line-height:1.4;">
+     style="pointer-events:auto;background:#2e7d32;color:#fff;padding:12px 16px;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.18);display:flex;align-items:flex-start;gap:12px;font-size:13px;line-height:1.4;animation:lvdcp-toast-fadeout 8s forwards;">
     <div style="flex:1;min-width:0;">
         <div style="font-weight:bold;margin-bottom:2px;">
             &#x2713; Wiki refresh status recovered

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.12-toast-autodismiss.md
+++ b/docs/release/2026-04-24-v0.8.12-toast-autodismiss.md
@@ -1,0 +1,155 @@
+# LV_DCP v0.8.12 — auto-dismiss for the recovery toast
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** the green "wiki refresh status recovered" toast (v0.8.11)
+now carries an inline `animation: lvdcp-toast-fadeout 8s forwards`
+so it auto-dismisses after ~8 s (6 s visible + 2 s fade). The red
+crash toast (v0.8.9) stays sticky. Closes the top UX gap from
+v0.8.11: a transient good-news flash shouldn't need a manual click.
+
+## Why
+
+v0.8.9 shipped a red crash toast that stays sticky until the user
+dismisses it — correct for bad news: a user scrolled away when the
+refresh crashed must find the banner waiting when they come back.
+v0.8.11 shipped a green recovery toast with the same sticky
+semantics — but that's wrong for good news. "We recovered" is
+acknowledged the moment the user sees it; leaving it pinned to the
+corner demands an extra click for zero information gain, and
+compounds when several recoveries happen during a volatile period.
+
+v0.8.12 fixes the asymmetry: recovery toasts fade out automatically,
+crash toasts still demand explicit acknowledgment. One-line change
+to the template, zero JS.
+
+## Shipped
+
+### Partial: `@keyframes lvdcp-toast-fadeout` alongside the toast
+
+```jinja
+{% if show_recovery_toast and slug %}
+<style>@keyframes lvdcp-toast-fadeout {
+    0%, 75% { opacity: 1; }
+    100% { opacity: 0; pointer-events: none; }
+}</style>
+<div id="recovery-toast-{{ slug }}"
+     hx-swap-oob="beforeend:#toast-region"
+     style="…green card…;animation:lvdcp-toast-fadeout 8s forwards;">
+    …
+</div>
+{% endif %}
+```
+
+- `0%, 75% { opacity: 1 }` → held at full opacity for the first 6 s of
+  the 8 s run.
+- `100% { opacity: 0; pointer-events: none }` → fades to invisible
+  over the final 2 s, and at the endpoint the element stops
+  intercepting clicks.
+- `animation-fill-mode: forwards` → pins the end state so the toast
+  stays invisible and non-interactive indefinitely without needing
+  JS cleanup.
+
+### Crash toast: explicitly unchanged
+
+No `animation` attribute, no keyframes reference. The red banner
+still sits in `#toast-region` until the user clicks dismiss. The
+asymmetry is the whole point.
+
+### Keyframes scoped to the conditional block
+
+The `<style>@keyframes …</style>` is inside `{% if show_recovery_
+toast %}` so a normal idle poll's response contains zero fadeout
+CSS. Two benefits:
+
+- Fragment payload stays small (saves ~140 bytes per poll).
+- When HTMX swaps several recovery responses in a row (can't happen
+  in practice, but possible if a pathological client forced it),
+  each one carries its own keyframes and the browser correctly
+  re-parses them.
+
+## Tests
+
+**+3 integration tests** in `tests/integration/test_ui_wiki_refresh.py`
+(30 total for this file now; the 27 from v0.8.7-v0.8.11 still pass
+unchanged):
+
+- `test_recovery_toast_carries_auto_dismiss_animation` — successful
+  recovery → body contains `animation:lvdcp-toast-fadeout 8s forwards`
+  AND `@keyframes lvdcp-toast-fadeout` AND `pointer-events: none`.
+- `test_crash_toast_does_not_carry_auto_dismiss_animation` — crash
+  transition → `id="crash-toast-…"` present, "Wiki refresh failed"
+  present, but `lvdcp-toast-fadeout` absent. Locks in the asymmetry.
+- `test_no_fadeout_keyframes_when_no_recovery_toast_rendered` —
+  clean idle poll → no `lvdcp-toast-fadeout` anywhere. Prevents
+  accidentally leaving the keyframes in a non-toast response.
+
+**Total suite: 1165 passing (+4 vs v0.8.11 — the Qdrant SSL flake
+also came back green this run).** Ruff + format + mypy strict clean
+across 374 source files.
+
+## Design notes
+
+- **Why 8 s (6 + 2), not 5 s or 10 s.** 5 s is too fast for a user
+  glancing at the corner, context-switching into the toast, and
+  parsing "we recovered" — they'd miss the fade. 10 s feels like the
+  server doesn't trust the user's attention. 8 s matches common
+  OS-level toast conventions (macOS Banner, Windows toast) and
+  leaves a fade long enough to be visually obvious without being
+  drawn-out.
+- **Why `0%, 75%` instead of `0% { opacity: 1 } 75% { opacity: 1 }`.**
+  CSS keyframes accept a comma-separated selector list; the
+  compressed form is idiomatic and a few bytes shorter.
+- **Why inline keyframes instead of a top-level style.** Consistency
+  with the running card's `@keyframes lvdcp-pulse` which is also
+  inlined in the partial. Keeps all wiki_refresh visual concerns in
+  one file; no need for a separate CSS bundle. The partial is
+  small enough that the duplication on repeated recovery fetches is
+  cheaper than the maintenance cost of a shared CSS file.
+- **Why `pointer-events: none` in the end keyframe.** Without it, the
+  invisible toast element would still sit on top of the underlying
+  page at `position: ...` within `#toast-region` and swallow clicks
+  on whatever was behind it (settings link, page reload, etc). The
+  dismiss button stays clickable during the visible window because
+  `pointer-events: auto` is set on the initial inline style and only
+  flipped off at the final keyframe.
+- **Why not `transition: opacity` instead of `animation`.** A
+  transition needs a trigger (the opacity value has to change), which
+  would require either a class flip from a `setTimeout` or a JS
+  `hidden` toggle. The animation fires automatically on DOM insertion
+  with no scripting. Pure HTML/CSS, matching the rest of the
+  wiki_refresh stack.
+- **Why keep the dismiss button.** Auto-dismiss handles the "I saw
+  it, moving on" case. Manual dismiss handles the "I want it gone
+  right now" case (e.g. several stacked recoveries during a volatile
+  incident). Costs nothing, keeps user agency.
+
+## Migration / compat
+
+- No DB migration, no new deps, no routing changes. The partial
+  gains ~200 bytes of inline CSS *only when* a recovery toast
+  renders. Non-toast responses are byte-identical to v0.8.11 except
+  for the footer version string.
+- No behavioural change for the crash toast — it stays sticky.
+- Browser requirement: CSS3 animations (i.e. everything since
+  ~2013). No polyfill needed.
+
+## Known gaps (carry-forward)
+
+- **No `prefers-reduced-motion` respect.** A user with reduced-motion
+  preferences would still get the fade. CSS-only workaround would
+  be a `@media (prefers-reduced-motion: reduce) { animation: none }`
+  block — one follow-up line. Deferred to keep v0.8.12 minimal.
+- **No pause-on-hover.** If the user is actively reading the toast
+  and the fade starts, they have no way to extend its life short of
+  moving the cursor off and back (which doesn't stop the animation
+  anyway). `animation-play-state: paused` on `:hover` would fix it.
+- **No "outage duration" label.** Same as v0.8.11 — requires the
+  server to remember when degraded mode started.
+- **Crash-toast manual-only still.** Intentional, but a future
+  pass could add a longer auto-dismiss (30-60 s) for crash toasts
+  that have been visible for a while, on the theory that if the
+  user didn't click after a full minute they're not going to.
+- **No telemetry.** Still no structured log event for
+  toast-rendered / toast-dismissed. Lowest-hanging observability
+  fruit across the last three releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.11"
+version = "0.8.12"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/test_ui_wiki_refresh.py
+++ b/tests/integration/test_ui_wiki_refresh.py
@@ -806,3 +806,102 @@ async def test_recovery_toast_absent_on_non_htmx_full_page_load(
     assert response.status_code == 200
     assert "Wiki refresh status recovered" not in response.text
     assert "recovery-toast-" not in response.text
+
+
+# -------- v0.8.12: recovery toast auto-dismiss ---------------------
+
+
+@pytest.mark.asyncio
+async def test_recovery_toast_carries_auto_dismiss_animation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recovery toast inline style includes the fadeout animation so it auto-dismisses.
+
+    Transient good news shouldn't require a manual click to clear. The
+    inline ``animation: lvdcp-toast-fadeout 8s forwards`` holds full
+    opacity for 6 s then fades over 2 s, and ``forwards`` pins the end
+    state (opacity 0 + pointer-events: none) so nothing blocks clicks
+    after it disappears. The @keyframes definition is inlined
+    alongside the toast so it's only in the DOM when the toast renders.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=3, elapsed_seconds=1.5)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={
+                "HX-Request": "true",
+                "X-LV-DCP-Was-Degraded": "true",
+            },
+        )
+
+    assert response.status_code == 200
+    # The toast itself must reference the animation.
+    assert "animation:lvdcp-toast-fadeout 8s forwards" in response.text
+    # The keyframes definition must be present so the animation resolves.
+    assert "@keyframes lvdcp-toast-fadeout" in response.text
+    # The fadeout must terminate at pointer-events: none so the invisible
+    # end-state doesn't intercept clicks on whatever is underneath.
+    assert "pointer-events: none" in response.text
+
+
+@pytest.mark.asyncio
+async def test_crash_toast_does_not_carry_auto_dismiss_animation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Crash toast stays sticky — bad news the user must acknowledge.
+
+    Auto-dismissing a 'wiki refresh failed' banner would be a UX bug: a
+    user scrolled away could miss the only signal that anything broke.
+    The recovery toast auto-dismisses, the crash toast does not; this
+    test locks in that asymmetry.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=2, modules_updated=1, elapsed_seconds=0.5)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    # Sanity: the crash toast is actually present.
+    assert "Wiki refresh failed" in response.text
+    assert f'id="crash-toast-{_slug(project)}' in response.text
+    # Asymmetry: the fadeout animation must NOT be attached to the crash toast.
+    assert "lvdcp-toast-fadeout" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_no_fadeout_keyframes_when_no_recovery_toast_rendered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Normal idle poll without a recovery toast ships zero unused fadeout CSS.
+
+    The keyframes block is scoped to the ``{% if show_recovery_toast %}``
+    guard so a clean idle body has no ``@keyframes lvdcp-toast-fadeout``
+    definition floating around. Keeps the fragment small and avoids
+    HTMX swapping in duplicate style nodes on every poll.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=2, elapsed_seconds=1.0)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        # Steady-state normal polling — no recovery, no crash.
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    assert "Last refresh: clean" in response.text
+    # No fadeout CSS because no toast is present.
+    assert "lvdcp-toast-fadeout" not in response.text


### PR DESCRIPTION
## Summary

- Closes the top UX gap from v0.8.11: the green "wiki refresh status recovered" toast stayed sticky — wrong semantics for transient good news. v0.8.12 adds `animation: lvdcp-toast-fadeout 8s forwards` so it auto-dismisses after 6 s visible + 2 s fade.
- Crash toast (v0.8.9) stays sticky on purpose. Bad news demands acknowledgment; good news does not. The asymmetry is the whole point.
- Zero JS. Pure CSS3 keyframes + `animation-fill-mode: forwards` + `pointer-events: none` at the end keyframe. Keyframes scoped to the `{% if show_recovery_toast %}` block so idle polls ship zero fadeout CSS.

## Test plan

- [x] `make lint` clean
- [x] `make format` clean
- [x] `make typecheck` clean
- [x] 3 new integration tests: recovery carries animation + keyframes; crash does not; no unused keyframes on clean idle
- [x] 30 tests in `tests/integration/test_ui_wiki_refresh.py` (all prior 27 still green)
- [x] Full suite: 1165 passing

## Release notes

See `docs/release/2026-04-24-v0.8.12-toast-autodismiss.md` for design rationale (why 8 s, why inline keyframes, why `pointer-events: none` at end, why animation over transition) and the carry-forward known-gaps list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)