### PR TITLE
release(v0.8.13): prefers-reduced-motion + hover-pause on recovery toast fade

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.12-toast-autodismiss.md)
-[![Version 0.8.12](https://img.shields.io/badge/version-0.8.12-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.13-toast-a11y.md)
+[![Version 0.8.13](https://img.shields.io/badge/version-0.8.13-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.13 (2026-04-24)** — Accessibility + hover polish on the recovery toast fade. Two carry-forward gaps from v0.8.12 closed in one pure-CSS patch: (a) `@media (prefers-reduced-motion: reduce)` cancels the fadeout animation entirely for users who've opted out of OS-level motion — the toast then stays sticky like the crash toast, manual dismiss only; (b) `.lvdcp-recovery-toast:hover { animation-play-state: paused !important }` freezes the fade while the cursor is over the toast — moving off resumes from the current opacity, no re-triggering. Both rules hang off a new `lvdcp-recovery-toast` class and live inside the same `{% if show_recovery_toast %}` guard as v0.8.12's keyframes, so idle polls still ship zero a11y CSS. `!important` needed because the v0.8.12 inline `animation:` shorthand has specificity 1000 — justified vs the alternative of breaking the shorthand into longhand or updating the v0.8.12 test. No JS, no new deps.
+
 **v0.8.12 (2026-04-24)** — Auto-dismiss for the recovery toast. The green "wiki refresh status recovered" banner (v0.8.11) now carries an inline `animation: lvdcp-toast-fadeout 8s forwards` so it fades and disappears ~8 s after it appears (6 s visible + 2 s fade). The red crash toast stays sticky — bad news needs acknowledgment, good news does not. Zero JS, no new deps; the `@keyframes` block is scoped to the `{% if show_recovery_toast %}` guard so normal idle polls ship zero fadeout CSS. The final keyframe flips `pointer-events: none` so the invisible end-state doesn't intercept clicks. Closes the top UX gap from v0.8.11 (transient good-news toast required a manual click).
 
 **v0.8.11 (2026-04-24)** — Recovery toast on the `wiki_refresh` degraded → normal transition. Symmetric to v0.8.9's red crash toast: on the exact polling tick that flips the panel out of degraded mode (v0.8.10), the fragment response also carries a green `hx-swap-oob` banner into `#toast-region` so scrolled-away users notice the self-heal. Detection is pure-HTMX: the degraded wrapper echoes `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`, HTMX sends the marker on the next poll, the route sees the header on a now-successful assembly and flips a one-shot toast on. The new successful wrapper omits the marker so the toast fires exactly once per recovery event. No cookies, no session store, no JS state. Closes the top known gap from v0.8.10 (silent self-heal).
@@ -90,6 +92,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.13-toast-a11y.md](docs/release/2026-04-24-v0.8.13-toast-a11y.md) (v0.8.13 — Accessibility + hover polish on the recovery toast fade)
 - [docs/release/2026-04-24-v0.8.12-toast-autodismiss.md](docs/release/2026-04-24-v0.8.12-toast-autodismiss.md) (v0.8.12 — Auto-dismiss for the recovery toast)
 - [docs/release/2026-04-24-v0.8.11-recovery-toast.md](docs/release/2026-04-24-v0.8.11-recovery-toast.md) (v0.8.11 — Recovery toast on `wiki_refresh` degraded → normal)
 - [docs/release/2026-04-24-v0.8.10-error-backoff.md](docs/release/2026-04-24-v0.8.10-error-backoff.md) (v0.8.10 — Error-backoff shell on `wiki_refresh` polling endpoint)
@@ -462,6 +465,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.10** (done) — Error-backoff shell on the `wiki_refresh` polling endpoint. `/api/project/{slug}/wiki-refresh` now wraps its status-assembly path in try/except: on any internal exception it returns 200 with the partial in degraded mode (yellow "refresh status unavailable" card + `hx-trigger="every 30s"` instead of `every 2s`). `except HTTPException: raise` preserves the 404-for-unknown-slug contract. Full-page `/project/<slug>` still 500s on real errors, so the degraded shell is scoped to continuous polling only. Closes the first operational known gap from v0.8.8 (500 mid-poll → HTMX hammers at 2 s; silent `None` → polling stops forever).
 - **v0.8.11** (done) — Recovery toast on `wiki_refresh` degraded → normal. Symmetric to v0.8.9's red crash toast: on the exact poll that flips the panel out of degraded mode, the fragment carries a green `hx-swap-oob` banner into `#toast-region`. Detection is pure-HTMX: the degraded wrapper sets `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`; the route sees the marker on a now-successful assembly and flips `show_recovery_toast=True` for exactly one response. The new successful wrapper omits the marker → no replay. No cookies, no session store, no JS. Closes the top known gap from v0.8.10 (silent self-heal).
 - **v0.8.12** (done) — Auto-dismiss for the recovery toast. Inline `animation: lvdcp-toast-fadeout 8s forwards` on the green toast only (crash toast stays sticky) — 6 s at full opacity, 2 s fade to `opacity: 0` + `pointer-events: none`. Zero JS, no new deps, ~200 bytes of inline CSS added only when the toast renders. Locks in the red/sticky vs green/transient UX asymmetry: bad news demands acknowledgment, good news fades. Closes the top UX gap from v0.8.11.
+- **v0.8.13** (done) — Accessibility + hover polish on the v0.8.12 fade. New `lvdcp-recovery-toast` class hook hangs two rules off the toast: `@media (prefers-reduced-motion: reduce) { animation: none !important; opacity: 1 !important; pointer-events: auto !important; }` cancels the fade for users who've opted out of OS-level motion (toast then stays sticky like the crash toast); `:hover { animation-play-state: paused !important; }` freezes the fade while the cursor is over the toast, resuming from the current opacity on mouse-out. `!important` needed to beat the inline `animation:` shorthand's specificity-1000. Both rules scoped to `{% if show_recovery_toast %}` so idle polls still ship zero a11y CSS. 1168 tests passing.
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -28,7 +28,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.12</span>
+        <span>LV_DCP Dashboard &bull; v0.8.13</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/ui/templates/partials/wiki_refresh.html.j2
+++ b/apps/ui/templates/partials/wiki_refresh.html.j2
@@ -192,12 +192,39 @@
    anything underneath. Dismiss button still works during the visible
    window for users who want to clear it immediately. The keyframes
    are inlined next to the toast so they're only present in the DOM
-   when the toast actually renders (no unused CSS on normal polls). #}
+   when the toast actually renders (no unused CSS on normal polls).
+
+   **Accessibility & hover polish (v0.8.13+).** The ``.lvdcp-recovery-
+   toast`` class hangs two small rules off the toast:
+
+     1. ``:hover { animation-play-state: paused !important; }`` — if
+        the user is actively reading the toast when the fade starts,
+        moving the cursor over it pauses the animation for as long as
+        they hover. Moving off resumes the fade from the current point
+        (not from zero). Answers the "I'm mid-glance, don't take this
+        away yet" case without adding a pause button.
+     2. ``@media (prefers-reduced-motion: reduce)`` kills the animation
+        entirely for users who've opted out of OS-level motion (screen
+        reader, vestibular sensitivity, etc.). The toast then stays
+        sticky like the crash toast — manual dismiss only — which is
+        the correct fallback: a user who explicitly disabled motion
+        won't miss a static banner, and we don't need JS to force a
+        delayed dismiss.
+
+   The ``!important`` on both rules exists because the inline ``animation``
+   shorthand on the element has higher specificity than a class rule.
+   Breaking the shorthand into longhand would avoid ``!important`` but
+   cost far more template weight than the three tokens save. #}
 <style>@keyframes lvdcp-toast-fadeout {
     0%, 75% { opacity: 1; }
     100% { opacity: 0; pointer-events: none; }
+}
+.lvdcp-recovery-toast:hover { animation-play-state: paused !important; }
+@media (prefers-reduced-motion: reduce) {
+    .lvdcp-recovery-toast { animation: none !important; opacity: 1 !important; pointer-events: auto !important; }
 }</style>
 <div id="recovery-toast-{{ slug }}"
+     class="lvdcp-recovery-toast"
      hx-swap-oob="beforeend:#toast-region"
      style="pointer-events:auto;background:#2e7d32;color:#fff;padding:12px 16px;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.18);display:flex;align-items:flex-start;gap:12px;font-size:13px;line-height:1.4;animation:lvdcp-toast-fadeout 8s forwards;">
     <div style="flex:1;min-width:0;">

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.13-toast-a11y.md
+++ b/docs/release/2026-04-24-v0.8.13-toast-a11y.md
@@ -1,0 +1,208 @@
+# LV_DCP v0.8.13 — accessibility + hover polish on the recovery toast fade
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** the green "wiki refresh status recovered" toast (v0.8.11)
+whose auto-dismiss fade landed in v0.8.12 now respects
+`prefers-reduced-motion` and pauses on hover. Closes two of the five
+known gaps carried forward from v0.8.12. Pure-CSS, zero JS.
+
+## Why
+
+v0.8.12 made the recovery toast auto-dismiss via
+`animation: lvdcp-toast-fadeout 8s forwards` — good for the median
+user, but two known gaps stayed open:
+
+1. **No `prefers-reduced-motion` respect.** A user with reduced-motion
+   preferences (screen reader, vestibular sensitivity, operating
+   system accessibility setting, etc.) still got the fade. On a
+   technical level the animation is tiny (opacity 1 → 0 over 2 s), but
+   the whole point of the OS flag is to let the user opt out — it's not
+   ours to second-guess.
+2. **No pause-on-hover.** A user mid-glance when the fade kicks in had
+   no way to extend the toast's life short of clicking dismiss mid-fade
+   (which feels racey on a 2 s animation). A proper hover-pause is a
+   one-line CSS rule.
+
+v0.8.13 ships both as a single accessibility + polish patch on the
+same `<style>` block, using a new `.lvdcp-recovery-toast` class as the
+hook. ~200 bytes of CSS added only when the toast renders.
+
+## Shipped
+
+### New class hook on the recovery toast
+
+```jinja
+<div id="recovery-toast-{{ slug }}"
+     class="lvdcp-recovery-toast"
+     hx-swap-oob="beforeend:#toast-region"
+     style="…green card…;animation:lvdcp-toast-fadeout 8s forwards;">
+```
+
+The class is inert on its own — its purpose is to be a target for the
+two new rules below. The `id` is kept because it's unique per-slug and
+useful for deterministic HTMX replacement; the `class` is reusable so
+future recovery-toast variants (e.g. a different success kind) could
+pick up the same a11y treatment automatically.
+
+### `@media (prefers-reduced-motion: reduce)` → animation off, stays sticky
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    .lvdcp-recovery-toast { animation: none !important; opacity: 1 !important; pointer-events: auto !important; }
+}
+```
+
+- `animation: none` — cancels the fadeout entirely.
+- `opacity: 1` — pins the toast at full opacity (without this, the
+  inline animation's computed end state from v0.8.12's `forwards`
+  fill-mode could still leak through in some browsers when
+  `animation-name` is reset).
+- `pointer-events: auto` — keeps the dismiss button clickable
+  indefinitely (without this, the `pointer-events: none` from the
+  100% keyframe would apply even though the animation is cancelled,
+  because `forwards` fill-mode can pin the last keyframe's state).
+
+Net effect: for a reduced-motion user the recovery toast behaves
+exactly like the crash toast — sticky, dismissable manually. That's
+the right fallback: a user who explicitly asked for no motion would
+rather have a persistent banner than a disappearing one they could
+miss.
+
+### `:hover { animation-play-state: paused !important }`
+
+```css
+.lvdcp-recovery-toast:hover { animation-play-state: paused !important; }
+```
+
+Moving the cursor onto the toast freezes the fade at its current
+opacity. Moving off resumes from that point (not from zero). No JS,
+no `setTimeout` arithmetic, no re-triggering. The browser handles
+it.
+
+### Why `!important` on both rules
+
+The v0.8.12 `animation: lvdcp-toast-fadeout 8s forwards` lives as an
+**inline style attribute** on the toast `<div>`. Inline styles have
+specificity 1000; a class rule has specificity 10 (or 20 with
+`:hover`). Without `!important`, the class rules would lose to the
+inline declaration. Two possible alternatives:
+
+- **Promote the `animation:` shorthand out of the inline style into
+  the class rule.** Cleaner specificity, no `!important`. Rejected
+  because it would break the v0.8.12 test
+  `test_recovery_toast_carries_auto_dismiss_animation` which asserts
+  the exact string `animation:lvdcp-toast-fadeout 8s forwards` is in
+  the inline style, and updating that test just to avoid three
+  `!important` flags felt like the wrong trade.
+- **Break the animation shorthand into longhand
+  (`animation-name`, `animation-duration`, …) and target only
+  `animation-play-state` from the class rule.** Avoids `!important`
+  but adds ~60 bytes to every recovery toast's inline style. Rejected
+  on weight grounds.
+
+Three `!important` tokens are cheap and local; the rules are scoped
+to a single class that only exists inside the `{% if
+show_recovery_toast %}` guard, so there's no risk of them leaking to
+other elements.
+
+### Everything else scoped to the conditional block
+
+The `<style>` tag is still inside `{% if show_recovery_toast and slug %}`,
+so a normal idle poll response ships **zero** fadeout CSS, **zero**
+media query, **zero** hover rule. Fragment stays small on the hot path.
+
+## Tests
+
+**+3 integration tests** in `tests/integration/test_ui_wiki_refresh.py`
+(33 total for this file now; the 30 from v0.8.7-v0.8.12 still pass
+unchanged):
+
+- `test_recovery_toast_respects_prefers_reduced_motion` — successful
+  recovery → body contains `class="lvdcp-recovery-toast"`,
+  `@media (prefers-reduced-motion: reduce)`, `animation: none !important`,
+  `opacity: 1 !important`, and `pointer-events: auto !important`.
+- `test_recovery_toast_pauses_on_hover` — successful recovery → body
+  contains `.lvdcp-recovery-toast:hover` and
+  `animation-play-state: paused !important`.
+- `test_no_a11y_css_when_no_recovery_toast_rendered` — clean idle poll
+  → body contains neither `prefers-reduced-motion` nor
+  `.lvdcp-recovery-toast:hover` nor even the `lvdcp-recovery-toast`
+  class hook. Parallel to v0.8.12's keyframes-scope test; locks in
+  that the new a11y CSS lives entirely under the same conditional
+  guard.
+
+**Total suite: 1168 passing (+3 vs v0.8.12 — Qdrant SSL flake also
+held green this run).** Ruff + format + mypy strict clean across 367
+source files.
+
+## Design notes
+
+- **Why reduced-motion makes the toast sticky, not a fast-dismiss.**
+  The two options for "user opted out of motion" are (a) no animation,
+  toast disappears via `display: none` after 8 s (needs JS), or
+  (b) no animation, toast stays forever (pure CSS). (b) is the
+  standard fallback when you can't animate — a reduced-motion user
+  expects static UI, not tricky timing-based vanishing. They'll close
+  it when they're ready. Same behaviour as the crash toast, which
+  they'd already see if they used the dashboard at all.
+- **Why hover-pause with no dedicated button.** The hover gesture is
+  cheap and universal (mouse, trackpad, touch-and-hold on mobile via
+  `:hover` compatibility). A dedicated pause button would add DOM
+  weight and a second affordance for a behaviour most users don't
+  need. Keeping the UX minimal.
+- **Why use a class rather than the id.** The id is `recovery-toast-
+  {{ slug }}` — per-project. A class rule works regardless of which
+  project's recovery toast is up, and opens the door to future toast
+  variants reusing the same accessibility treatment.
+- **Why `opacity: 1 !important` on the reduced-motion rule even
+  though `animation: none` already cancels the animation.** Browser
+  behaviour around `forwards` fill-mode and animation cancellation is
+  inconsistent across engines: WebKit historically retained the final
+  keyframe's computed values even after the animation-name was set to
+  none, which would leave the toast invisible. The explicit
+  `opacity: 1` guarantees the toast is visible regardless of browser.
+  Defence in depth for ~12 bytes.
+- **Why `pointer-events: auto !important`.** Same reason:
+  the end keyframe has `pointer-events: none`, and even with
+  `animation: none`, the `forwards` fill-mode on an in-flight
+  animation had historically pinned the final state in some
+  engines. Explicit `auto` restores clickability unconditionally.
+
+## Migration / compat
+
+- No DB migration, no new deps, no routing changes.
+- The partial gains ~200 bytes of inline CSS *only when* a recovery
+  toast renders. Non-toast responses are byte-identical to v0.8.12
+  except the footer version string.
+- No behavioural change for the crash toast — still sticky.
+- No behavioural change for the recovery toast on a default-motion
+  user — still fades in 8 s as in v0.8.12.
+- Browser requirement: CSS3 animations + `prefers-reduced-motion`
+  media query — all browsers since ~2019. Older browsers (IE11,
+  legacy Edge) would simply ignore the media query and get the fade;
+  acceptable, since we don't support those.
+
+## Known gaps (carry-forward)
+
+- **No "outage duration" label on the recovery toast.** Same as
+  v0.8.11/v0.8.12 — requires the server to remember when degraded
+  mode started. A Redis / in-memory tracker would make this a small
+  follow-up; still deferred.
+- **Crash-toast still manual-only.** Intentional, but a future pass
+  could add a very long auto-dismiss (30-60 s) for crash toasts
+  visible on the screen for a full minute without a click — on the
+  theory that if the user didn't dismiss after a minute they're not
+  going to.
+- **No telemetry.** Still no structured log event for
+  toast-rendered / toast-dismissed. Lowest-hanging observability
+  fruit across the last four releases. Strong candidate for v0.8.14.
+- **No `Retry now` button on the degraded card.** The degraded card
+  polls at 30 s — a user who knows the underlying infra just came
+  back could still wait up to that long. A tiny button could force
+  an immediate refetch. Deferred.
+- **No `forced-colors` (Windows High Contrast) styling.** Reduced-
+  motion is handled; forced-colors is not. Low priority — our
+  colour palette already uses semantic background + high-contrast
+  text, but an explicit `forced-colors: active` media query would
+  be the rigorous fix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.12"
+version = "0.8.13"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/test_ui_wiki_refresh.py
+++ b/tests/integration/test_ui_wiki_refresh.py
@@ -905,3 +905,111 @@ async def test_no_fadeout_keyframes_when_no_recovery_toast_rendered(
     assert "Last refresh: clean" in response.text
     # No fadeout CSS because no toast is present.
     assert "lvdcp-toast-fadeout" not in response.text
+
+
+# -------- v0.8.13: accessibility + hover polish on the fadeout -------
+
+
+@pytest.mark.asyncio
+async def test_recovery_toast_respects_prefers_reduced_motion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recovery toast carries a ``prefers-reduced-motion`` media query.
+
+    Users who've opted out of OS-level motion (screen reader, vestibular
+    sensitivity, etc.) should not see the fade — the toast stays sticky
+    like the crash toast instead. The rule is ``animation: none``,
+    ``opacity: 1``, ``pointer-events: auto`` (all ``!important`` to
+    override the inline ``animation`` shorthand). The ``.lvdcp-recovery-
+    toast`` class must be attached to the toast div so the rule has a
+    target to hit.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=3, elapsed_seconds=1.5)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={
+                "HX-Request": "true",
+                "X-LV-DCP-Was-Degraded": "true",
+            },
+        )
+
+    assert response.status_code == 200
+    # The class hook must be present on the toast div.
+    assert 'class="lvdcp-recovery-toast"' in response.text
+    # The reduced-motion media query must be present.
+    assert "@media (prefers-reduced-motion: reduce)" in response.text
+    # Inside it, the animation must be cancelled and full opacity pinned.
+    assert "animation: none !important" in response.text
+    assert "opacity: 1 !important" in response.text
+    # And the toast must remain interactive (dismiss button stays clickable).
+    assert "pointer-events: auto !important" in response.text
+
+
+@pytest.mark.asyncio
+async def test_recovery_toast_pauses_on_hover(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recovery toast CSS pauses the fade animation while the cursor is over it.
+
+    If a user is mid-glance when the fade starts, moving the cursor onto
+    the toast freezes it at the current opacity. Moving off resumes.
+    Implemented as ``.lvdcp-recovery-toast:hover { animation-play-state:
+    paused !important; }`` — ``!important`` is needed to override the
+    inline ``animation`` shorthand which resets play-state to ``running``.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=3, elapsed_seconds=1.5)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={
+                "HX-Request": "true",
+                "X-LV-DCP-Was-Degraded": "true",
+            },
+        )
+
+    assert response.status_code == 200
+    # Class selector for hover is present.
+    assert ".lvdcp-recovery-toast:hover" in response.text
+    # Paused state is applied with !important to beat the inline shorthand.
+    assert "animation-play-state: paused !important" in response.text
+
+
+@pytest.mark.asyncio
+async def test_no_a11y_css_when_no_recovery_toast_rendered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Normal idle poll without a recovery toast ships zero a11y CSS.
+
+    Parallel to ``test_no_fadeout_keyframes_when_no_recovery_toast_
+    rendered``: the hover rule and the ``prefers-reduced-motion`` media
+    query live inside the same ``{% if show_recovery_toast %}`` guard as
+    the keyframes, so a clean idle response must not carry them either.
+    Prevents accidentally leaving a11y rules in a non-toast response.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=2, elapsed_seconds=1.0)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    assert "Last refresh: clean" in response.text
+    # Neither the media query nor the hover selector nor the class hook
+    # should be present when no toast renders.
+    assert "prefers-reduced-motion" not in response.text
+    assert ".lvdcp-recovery-toast:hover" not in response.text
+    assert "lvdcp-recovery-toast" not in response.text

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "lv-dcp"
-version = "0.8.11"
+version = "0.8.12"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Closes two carry-forward gaps from v0.8.12 in one pure-CSS patch.
- `@media (prefers-reduced-motion: reduce)` cancels the fade for users who've opted out of OS-level motion — the toast stays sticky like the crash toast, manual dismiss only.
- `.lvdcp-recovery-toast:hover { animation-play-state: paused !important; }` freezes the fade while the cursor is over the toast; moving off resumes from the current opacity.
- Both rules hang off a new `lvdcp-recovery-toast` class and live inside the same `{% if show_recovery_toast %}` guard as v0.8.12's keyframes — idle polls still ship zero a11y CSS. `!important` justified vs alternatives (see release notes).

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean (367 files)
- [x] `mypy --strict` clean (170 source files)
- [x] 3 new integration tests: reduced-motion media query present; hover rule present; neither present on idle polls
- [x] 33 tests in `tests/integration/test_ui_wiki_refresh.py` (all prior 30 still green)
- [x] Full suite: **1168 passing, 0 failed**

## Release notes

See `docs/release/2026-04-24-v0.8.13-toast-a11y.md` for design rationale (why sticky-not-fast-dismiss on reduced-motion, why hover-pause without a dedicated button, why class-not-id, why `opacity: 1` and `pointer-events: auto` needed even though `animation: none` already cancels, why `!important`) and the updated carry-forward gaps list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)