### PR TITLE
release(v0.8.14): Retry now escape hatch on the wiki_refresh degraded card

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Local-first engineering memory.** Turns projects on macOS into a queryable context layer for Claude, IDE agents, and humans. Supports Python, TypeScript/JS, Go, and Rust. Reduces token cost of repeated code reading, builds a relation graph, and makes agent edits safer.
 
-[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.13-toast-a11y.md)
-[![Version 0.8.13](https://img.shields.io/badge/version-0.8.13-blue)](pyproject.toml)
+[![Phase 9 Complete](https://img.shields.io/badge/phase-9%20complete-green)](docs/release/2026-04-24-v0.8.14-retry-now.md)
+[![Version 0.8.14](https://img.shields.io/badge/version-0.8.14-blue)](pyproject.toml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)](pyproject.toml)
 
@@ -53,6 +53,8 @@ $ ctx pack . "refresh token rotation" --mode edit
 
 ## Status
 
+**v0.8.14 (2026-04-24)** — "Retry now" escape hatch on the `wiki_refresh` degraded card. The yellow "refresh status unavailable" card (v0.8.10) now carries a small Retry button that fires the same polling endpoint on click — identical `hx-get` / `hx-target="#wiki-refresh-panel"` / `hx-swap="outerHTML"` as the auto-poll, plus `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'` so a successful manual retry triggers the green recovery toast exactly like an auto-recovery would. `hx-disabled-elt="this"` prevents double-click races. A user who knows (restarted infra, migration finished, etc.) that the service is back no longer has to wait up to 30 s for the next tick. No new route, no new JS, button scoped strictly to `{% if degraded %}` so it never appears on healthy responses. Closes the "Retry now" carry-forward gap from v0.8.10-v0.8.13.
+
 **v0.8.13 (2026-04-24)** — Accessibility + hover polish on the recovery toast fade. Two carry-forward gaps from v0.8.12 closed in one pure-CSS patch: (a) `@media (prefers-reduced-motion: reduce)` cancels the fadeout animation entirely for users who've opted out of OS-level motion — the toast then stays sticky like the crash toast, manual dismiss only; (b) `.lvdcp-recovery-toast:hover { animation-play-state: paused !important }` freezes the fade while the cursor is over the toast — moving off resumes from the current opacity, no re-triggering. Both rules hang off a new `lvdcp-recovery-toast` class and live inside the same `{% if show_recovery_toast %}` guard as v0.8.12's keyframes, so idle polls still ship zero a11y CSS. `!important` needed because the v0.8.12 inline `animation:` shorthand has specificity 1000 — justified vs the alternative of breaking the shorthand into longhand or updating the v0.8.12 test. No JS, no new deps.
 
 **v0.8.12 (2026-04-24)** — Auto-dismiss for the recovery toast. The green "wiki refresh status recovered" banner (v0.8.11) now carries an inline `animation: lvdcp-toast-fadeout 8s forwards` so it fades and disappears ~8 s after it appears (6 s visible + 2 s fade). The red crash toast stays sticky — bad news needs acknowledgment, good news does not. Zero JS, no new deps; the `@keyframes` block is scoped to the `{% if show_recovery_toast %}` guard so normal idle polls ship zero fadeout CSS. The final keyframe flips `pointer-events: none` so the invisible end-state doesn't intercept clicks. Closes the top UX gap from v0.8.11 (transient good-news toast required a manual click).
@@ -92,6 +94,7 @@ $ ctx pack . "refresh token rotation" --mode edit
 Stabilization 0.6.1 baseline: mandatory GitHub Actions quality gates, green `ruff` / `mypy`, runtime-hardened embeddings and Qdrant.
 
 Release notes:
+- [docs/release/2026-04-24-v0.8.14-retry-now.md](docs/release/2026-04-24-v0.8.14-retry-now.md) (v0.8.14 — "Retry now" escape hatch on the degraded card)
 - [docs/release/2026-04-24-v0.8.13-toast-a11y.md](docs/release/2026-04-24-v0.8.13-toast-a11y.md) (v0.8.13 — Accessibility + hover polish on the recovery toast fade)
 - [docs/release/2026-04-24-v0.8.12-toast-autodismiss.md](docs/release/2026-04-24-v0.8.12-toast-autodismiss.md) (v0.8.12 — Auto-dismiss for the recovery toast)
 - [docs/release/2026-04-24-v0.8.11-recovery-toast.md](docs/release/2026-04-24-v0.8.11-recovery-toast.md) (v0.8.11 — Recovery toast on `wiki_refresh` degraded → normal)
@@ -466,6 +469,7 @@ The daemon uses `watchdog.observers.Observer` which auto-selects `FSEventsObserv
 - **v0.8.11** (done) — Recovery toast on `wiki_refresh` degraded → normal. Symmetric to v0.8.9's red crash toast: on the exact poll that flips the panel out of degraded mode, the fragment carries a green `hx-swap-oob` banner into `#toast-region`. Detection is pure-HTMX: the degraded wrapper sets `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`; the route sees the marker on a now-successful assembly and flips `show_recovery_toast=True` for exactly one response. The new successful wrapper omits the marker → no replay. No cookies, no session store, no JS. Closes the top known gap from v0.8.10 (silent self-heal).
 - **v0.8.12** (done) — Auto-dismiss for the recovery toast. Inline `animation: lvdcp-toast-fadeout 8s forwards` on the green toast only (crash toast stays sticky) — 6 s at full opacity, 2 s fade to `opacity: 0` + `pointer-events: none`. Zero JS, no new deps, ~200 bytes of inline CSS added only when the toast renders. Locks in the red/sticky vs green/transient UX asymmetry: bad news demands acknowledgment, good news fades. Closes the top UX gap from v0.8.11.
 - **v0.8.13** (done) — Accessibility + hover polish on the v0.8.12 fade. New `lvdcp-recovery-toast` class hook hangs two rules off the toast: `@media (prefers-reduced-motion: reduce) { animation: none !important; opacity: 1 !important; pointer-events: auto !important; }` cancels the fade for users who've opted out of OS-level motion (toast then stays sticky like the crash toast); `:hover { animation-play-state: paused !important; }` freezes the fade while the cursor is over the toast, resuming from the current opacity on mouse-out. `!important` needed to beat the inline `animation:` shorthand's specificity-1000. Both rules scoped to `{% if show_recovery_toast %}` so idle polls still ship zero a11y CSS. 1168 tests passing.
+- **v0.8.14** (done) — "Retry now" escape hatch on the degraded card. Adds a small button inside `{% if degraded %}` that hits `GET /api/project/<slug>/wiki-refresh` via `hx-get` + `hx-target="#wiki-refresh-panel"` + `hx-swap="outerHTML"` + `hx-disabled-elt="this"`, echoing the same `X-LV-DCP-Was-Degraded` marker the polling wrapper sends. Marker parity means a successful manual click flips `show_recovery_toast=True` and fires the green recovery toast exactly like an auto-recovery would — identical success UX regardless of trigger source. Scoped to degraded mode only, no new route, no JS. Closes the user-agency gap carried from v0.8.10. 1171 tests passing.
 - **Phase 10** (next) — Java/Kotlin/Swift parsers, VS Code marketplace, Obsidian nightly sync.
 
 ## Contributing

--- a/apps/ui/templates/base.html.j2
+++ b/apps/ui/templates/base.html.j2
@@ -28,7 +28,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <span>LV_DCP Dashboard &bull; v0.8.13</span>
+        <span>LV_DCP Dashboard &bull; v0.8.14</span>
         <a href="#" onclick="window.location.reload(); return false;">refresh</a>
     </footer>
     <script src="/static/js/dashboard.js"></script>

--- a/apps/ui/templates/partials/wiki_refresh.html.j2
+++ b/apps/ui/templates/partials/wiki_refresh.html.j2
@@ -74,6 +74,33 @@
         <div style="font-size:13px;color:#555;margin-top:4px;">
             Temporarily unable to read refresh state. Retrying every 30s&hellip;
         </div>
+        {# v0.8.14+: manual "Retry now" escape hatch. The degraded wrapper
+           already polls every 30s, but a user who knows the underlying
+           infra just came back shouldn't have to wait up to that long.
+           The button fires the same endpoint as the polling tick and
+           carries the same ``X-LV-DCP-Was-Degraded`` marker header, so:
+             - if the retry succeeds, the route flips ``show_recovery_
+               toast=True`` and the green toast fires exactly once
+               (same code path as the auto-recovery);
+             - if it's still degraded, the response re-renders this same
+               card (with the marker re-echoed in ``hx-headers``), so
+               clicking Retry again is fine.
+           ``hx-target`` + ``hx-swap`` point at the outer wrapper so the
+           swap replaces the whole panel — identical to what the polling
+           tick does. ``hx-disabled-elt="this"`` prevents a double-click
+           from firing two parallel requests. #}
+        {% if slug %}
+        <button type="button"
+                id="wiki-refresh-retry-{{ slug }}"
+                hx-get="/api/project/{{ slug }}/wiki-refresh"
+                hx-target="#wiki-refresh-panel"
+                hx-swap="outerHTML"
+                hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'
+                hx-disabled-elt="this"
+                style="margin-top:10px;padding:4px 10px;background:#fff;color:#795548;border:1px solid #f9a825;border-radius:4px;font-size:12px;cursor:pointer;">
+            Retry now
+        </button>
+        {% endif %}
     </div>
 </section>
 {% elif wr and (wr.in_progress or wr.last_exit_code is not none) %}

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "lv-dcp",
     "displayName": "LV_DCP — Developer Context Platform",
     "description": "Context packs and impact analysis for your codebase",
-    "version": "0.8.13",
+    "version": "0.8.14",
     "publisher": "lv-dcp",
     "engines": {
         "vscode": "^1.85.0"

--- a/docs/release/2026-04-24-v0.8.14-retry-now.md
+++ b/docs/release/2026-04-24-v0.8.14-retry-now.md
@@ -1,0 +1,178 @@
+# LV_DCP v0.8.14 — "Retry now" escape hatch on the degraded card
+
+**Date:** 2026-04-24
+**Status:** Released
+**Scope:** the yellow "refresh status unavailable" card (v0.8.10) now
+carries a Retry-now button so a user who knows infra just came back
+can force an immediate retry instead of waiting up to 30 s for the
+polling tick. Closes the "`Retry now` button on the degraded card"
+carry-forward gap from v0.8.10/v0.8.11/v0.8.12/v0.8.13.
+
+## Why
+
+v0.8.10 shipped a degraded shell with 30 s polling: the panel
+self-heals without hammering the server. Correct for the unattended
+case (user tabs away and comes back — the panel has already
+recovered). Wrong for the attended case: a user watching the
+dashboard, who knows (because they restarted the infra, ran a
+migration, woke the laptop from sleep, etc.) that the service is
+back, shouldn't have to wait up to 30 s to see the confirmation.
+
+v0.8.14 adds a Retry-now button inside the degraded card. Same
+endpoint, same headers, same success semantics as the polling tick —
+just with a click as the trigger source.
+
+## Shipped
+
+### Button, scoped to the `{% if degraded %}` branch
+
+```jinja
+{% if slug %}
+<button type="button"
+        id="wiki-refresh-retry-{{ slug }}"
+        hx-get="/api/project/{{ slug }}/wiki-refresh"
+        hx-target="#wiki-refresh-panel"
+        hx-swap="outerHTML"
+        hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'
+        hx-disabled-elt="this"
+        style="margin-top:10px;padding:4px 10px;background:#fff;color:#795548;border:1px solid #f9a825;border-radius:4px;font-size:12px;cursor:pointer;">
+    Retry now
+</button>
+{% endif %}
+```
+
+- `hx-get="/api/project/{{ slug }}/wiki-refresh"` — the exact endpoint
+  the polling tick hits. No new route, no new route logic.
+- `hx-target="#wiki-refresh-panel"` + `hx-swap="outerHTML"` — target
+  the outer wrapper so the response replaces the whole panel,
+  identical to what the polling tick does on itself.
+- `hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'` — **trigger-source
+  parity.** The polling wrapper already carries this marker so a
+  successful poll flips `show_recovery_toast=True` and fires the
+  green recovery toast (v0.8.11). The button must carry the same
+  marker or a successful manual retry would silently swap in a
+  normal card without the "recovered" confirmation — violating the
+  invariant that a user sees the same success UX regardless of
+  whether they waited for the poll or clicked Retry.
+- `hx-disabled-elt="this"` — HTMX automatically disables the element
+  while the request is in flight, preventing a double-click from
+  firing two parallel requests. The attribute is one line and costs
+  nothing; without it, a fast double-click could race.
+- `id="wiki-refresh-retry-{{ slug }}"` — unique per project, testable.
+
+### Styling matches the yellow card
+
+- Background `#fff`, border `1px solid #f9a825` (same tone as the
+  card's left border), text `#795548` (same brown as the title).
+  Reads as "paired with the yellow card" rather than a shouty
+  CTA button. Size-wise it's a modest 12px badge — present
+  without pushing the card taller.
+
+### Scope guarantee
+
+The button lives inside the `{% if degraded %}` branch. A clean
+idle response, a running refresh, a finished-with-error card — none
+of them render the button. Locks in that Retry-now is a
+degraded-mode-only affordance: we're not giving users a generic
+"force poll" button that works on any state, because we don't want
+them paying the full `build_workspace_status` cost on every click.
+
+## Tests
+
+**+3 integration tests** in `tests/integration/test_ui_wiki_refresh.py`
+(36 total for this file now; the 33 from v0.8.7-v0.8.13 still pass
+unchanged):
+
+- `test_degraded_card_carries_retry_now_button` — force degraded via
+  monkeypatched `build_wiki_refresh` → body contains the button id,
+  `hx-get` pointing at the same endpoint, `hx-target` on the outer
+  wrapper, `hx-swap="outerHTML"`, and `hx-disabled-elt="this"`.
+- `test_retry_now_button_absent_on_happy_path` — clean last run →
+  neither the "Retry now" text nor the button id appears. Locks in
+  the scope invariant.
+- `test_retry_now_button_carries_was_degraded_marker_for_recovery_toast`
+  — degraded response must carry the `X-LV-DCP-Was-Degraded` marker
+  **twice**: once on the polling wrapper (the v0.8.11 contract) and
+  once on the Retry button (v0.8.14). Parity = identical recovery-
+  toast UX from either trigger source.
+
+**Total suite: 1171 passing (+3 vs v0.8.13).** Ruff + format + mypy
+strict clean across 367/170 source files.
+
+## Design notes
+
+- **Why no separate `/api/project/<slug>/wiki-refresh/retry` route.**
+  The existing endpoint is idempotent (reads current status, doesn't
+  mutate). A "retry" is literally just "fetch the current status
+  again" — no separate action, no side effects to sequence. A new
+  route would be ceremony for zero gain.
+- **Why target the outer wrapper, not the button.** `hx-target="this"`
+  would only swap the button itself, leaving the degraded card
+  around it — so a successful retry would replace the button with a
+  normal card fragment inside the yellow card. Ugly and wrong. Same
+  target the polling tick uses (`#wiki-refresh-panel`) gives identical
+  swap behaviour.
+- **Why `hx-disabled-elt="this"` and not JavaScript.** HTMX has built-in
+  request-in-flight handling — adds `disabled` to the element for the
+  duration of the request. Pure HTML attribute, no JS, no race
+  conditions on setTimeout-based approaches.
+- **Why marker parity with the polling wrapper.** Imagine: infra
+  recovers exactly at second 28. The polling tick would fire at
+  second 30 with the marker, get the success response, render the
+  recovery toast. But if the user clicks Retry at second 29, the
+  click goes through, infra is back, the server assembles a
+  successful response — but without the marker, `show_recovery_toast`
+  would be False and the toast wouldn't fire. The user would see
+  the card replaced silently, wondering "did it work?". Marker parity
+  means the button fires on the same contract as the poll.
+- **Why no loading spinner inside the button.** HTMX flips the
+  element to `disabled` during the request via `hx-disabled-elt`.
+  Browsers render disabled buttons in a muted state, which is a
+  sufficient visual cue. Adding a spinner would need JS or extra
+  CSS and buy very little — requests to this endpoint typically
+  return in <100 ms.
+- **Why the slug guard.** The button depends on `{{ slug }}` for its
+  id and URL. If the degraded branch is entered without a slug
+  (legacy code paths, test harnesses), the `{% if slug %}` guard
+  prevents rendering a button with an empty URL. The rest of the
+  card still works.
+- **Why not also add Retry to the crash card.** Different failure mode.
+  The degraded state means "we couldn't read status" — retrying
+  might succeed. The crash state means "the refresh process itself
+  died" — retrying by clicking a button in the status panel doesn't
+  re-run the refresh. A "retry the wiki refresh" button belongs in
+  a different surface (the project control panel, not the status
+  view), and `ctx project refresh --wiki` already serves that flow.
+
+## Migration / compat
+
+- No DB migration, no new deps, no new routes, no route logic changes.
+- The partial gains ~400 bytes of markup *only when* the degraded
+  branch renders. Non-degraded responses are byte-identical to
+  v0.8.13 except the footer version string.
+- No behavioural change for non-degraded states — button lives
+  strictly inside the `{% if degraded %}` block.
+- No JS required beyond the HTMX library already loaded since v0.8.8.
+
+## Known gaps (carry-forward)
+
+- **No telemetry.** Still the biggest unclosed gap across five
+  releases. Now includes a new event type to count: Retry-button
+  clicks vs auto-poll recoveries. Strong candidate for v0.8.15.
+- **No "outage duration" label on the recovery toast or degraded
+  card.** Requires the server to remember when degraded mode started
+  (Redis or in-memory tracker). Still deferred.
+- **No `forced-colors` (Windows High Contrast) styling** on either the
+  degraded card or the Retry button. The button's `color` and
+  `border-color` inline values would be overridden by the OS theme,
+  but we haven't verified it. Low priority.
+- **Crash-toast still manual-only**, intentional. If v0.8.15 adds
+  telemetry, there'd be data to drive a long auto-dismiss heuristic
+  ("toast visible > 60 s without click → fade").
+- **No rate limit on Retry clicks.** `hx-disabled-elt` prevents
+  double-clicks during a single request, but a user could click
+  Retry, wait for the response, click again, and so on — no server-
+  side throttle. In practice the endpoint is cheap and the degraded
+  branch only fires when infra is actually struggling (when you'd
+  *want* a retry), so this is fine. A future `429 Too Many Requests`
+  on repeated immediate Retries would be the formal fix if needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lv-dcp"
-version = "0.8.13"
+version = "0.8.14"
 description = "LV_DCP — Developer Context Platform. Local-first engineering memory for macOS."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/test_ui_wiki_refresh.py
+++ b/tests/integration/test_ui_wiki_refresh.py
@@ -1013,3 +1013,124 @@ async def test_no_a11y_css_when_no_recovery_toast_rendered(
     assert "prefers-reduced-motion" not in response.text
     assert ".lvdcp-recovery-toast:hover" not in response.text
     assert "lvdcp-recovery-toast" not in response.text
+
+
+# -------- v0.8.14: "Retry now" button on the degraded card -----------
+
+
+@pytest.mark.asyncio
+async def test_degraded_card_carries_retry_now_button(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Degraded response renders a button that hits the same endpoint on click.
+
+    The 30s polling is a fallback, not the only escape hatch. A user who
+    knows infra just came back should be able to force a retry. The
+    button uses HTMX (``hx-get`` + ``hx-target`` + ``hx-swap`` pointing
+    at the outer wrapper), identical to what the polling tick does on
+    itself — so on success the wiki_refresh panel is replaced with the
+    real card, on continued failure the degraded card is re-rendered
+    in place.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+
+    import apps.ui.routes.project as project_route
+
+    def _boom(_root: Path) -> object:
+        raise RuntimeError("transient hiccup")
+
+    monkeypatch.setattr(project_route, "build_wiki_refresh", _boom)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    # Sanity: we're in the degraded branch.
+    assert "Refresh status unavailable" in response.text
+    # Button text, id, and all the HTMX attrs must be there.
+    assert (
+        ">Retry now</button>" in response.text.replace("\n", "").replace("        ", "")
+        or "Retry now" in response.text
+    )
+    assert f'id="wiki-refresh-retry-{_slug(project)}"' in response.text
+    assert f'hx-get="/api/project/{_slug(project)}/wiki-refresh"' in response.text
+    # Target the outer wrapper so the swap replaces the whole panel.
+    assert 'hx-target="#wiki-refresh-panel"' in response.text
+    assert 'hx-swap="outerHTML"' in response.text
+    # ``hx-disabled-elt`` prevents a double-click from firing two parallel reqs.
+    assert 'hx-disabled-elt="this"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_retry_now_button_absent_on_happy_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-degraded responses do not render the Retry button.
+
+    The button lives inside the ``{% if degraded %}`` branch, so a clean
+    last-run render — or a running refresh render — must never carry it.
+    Locks in the scope invariant: Retry now is a degraded-mode-only
+    affordance, not a general "force poll" button.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+    write_last_refresh(project, exit_code=0, modules_updated=5, elapsed_seconds=2.0)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    assert "Last refresh: clean" in response.text
+    assert "Retry now" not in response.text
+    assert f'id="wiki-refresh-retry-{_slug(project)}"' not in response.text
+
+
+@pytest.mark.asyncio
+async def test_retry_now_button_carries_was_degraded_marker_for_recovery_toast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retry button echoes the same recovery marker the polling wrapper does.
+
+    The wrapper element in degraded mode carries
+    ``hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`` so the next
+    successful poll gets the recovery toast. The Retry-now button must
+    carry the exact same marker — otherwise clicking Retry at the
+    moment infra recovers would silently return a normal card without
+    the "recovered" confirmation, and the user would wonder whether
+    the click did anything. Marker parity means manual retry and auto
+    retry have identical success UX.
+    """
+    project = _seed_project(tmp_path, monkeypatch)
+
+    import apps.ui.routes.project as project_route
+
+    def _boom(_root: Path) -> object:
+        raise RuntimeError("transient hiccup")
+
+    monkeypatch.setattr(project_route, "build_wiki_refresh", _boom)
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/project/{_slug(project)}/wiki-refresh",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    # Both the wrapper (for polling) AND the button (for manual click)
+    # must carry the marker. Parity = identical recovery-toast UX from
+    # either trigger source.
+    assert response.text.count('hx-headers=\'{"X-LV-DCP-Was-Degraded": "true"}\'') >= 2, (
+        "Expected the X-LV-DCP-Was-Degraded marker on BOTH the polling "
+        "wrapper and the Retry button."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "lv-dcp"
-version = "0.8.12"
+version = "0.8.13"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Closes the "user-agency on degraded polling" gap carried from v0.8.10. A user who knows infra just came back no longer waits up to 30 s for the next tick — a small Retry button fires the same endpoint on click.
- Marker parity with the polling wrapper (`hx-headers='{"X-LV-DCP-Was-Degraded": "true"}'`) — manual retries trigger the green recovery toast exactly like auto-recovery does. Same success UX regardless of trigger source.
- Scoped strictly to `{% if degraded %}` and guarded by `{% if slug %}`. No new routes, no JS. `hx-disabled-elt="this"` prevents double-click races.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean (367 files)
- [x] `mypy --strict` clean (170 source files)
- [x] 3 new integration tests: button present on degraded / absent on happy / marker parity
- [x] 36 tests in `tests/integration/test_ui_wiki_refresh.py` (all prior 33 still green)
- [x] Full suite: **1171 passing, 0 failed**

## Release notes

See `docs/release/2026-04-24-v0.8.14-retry-now.md` for design rationale (why no new endpoint, why target the outer wrapper, why marker parity matters, why no crash-card Retry, why no spinner, why no rate-limit) and the updated carry-forward list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)